### PR TITLE
Reorder badges based on feedback.

### DIFF
--- a/src/badge/accolade/_accolade-badges.ts
+++ b/src/badge/accolade/_accolade-badges.ts
@@ -133,6 +133,9 @@ import {YesterdaysNews} from "./yesterdays-news";
 import {ZigWarden} from "./zig-warden";
 
 export const AccoladeBadges: IBadgeData[] = [
+    ThornRobber,
+    ThornThief,
+    ThornUsurper,
     FalseImage,
     SharkBait,
     AntiVenom,
@@ -260,9 +263,6 @@ export const AccoladeBadges: IBadgeData[] = [
     ReceivedTheStalwartMedallion,
     EarnedTheStatesmanStar,
     AwardedTheFreedomCross,
-    ThornRobber,
-    ThornThief,
-    ThornUsurper,
     DestroyerOfDespair,
     GeasOfTheKindOnes,
     Chronomaster

--- a/src/badge/achievement/_achievement-badges.ts
+++ b/src/badge/achievement/_achievement-badges.ts
@@ -300,7 +300,6 @@ export const AchievementBadges: IBadgeData[] = [
     GuardianOfForever,
     DeadlyCombatant,
     DignifiedCombatant,
-    BailoutHero,
     Avenger,
     DiamondInTheRough,
     BeyondReasonableDoubt,
@@ -311,6 +310,7 @@ export const AchievementBadges: IBadgeData[] = [
     LoneWolf,
     BuddyCop,
     IncarnateRival,
+    BailoutHero,
 
     //Incarnate Taskforces
     DroneProtector,


### PR DESCRIPTION
Bailout hero and treespec badges were out of place

Ref: 

- https://forums.homecomingservers.com/topic/11333-new-badge-tracker/?do=findComment&comment=118698
- https://forums.homecomingservers.com/topic/11333-new-badge-tracker/?do=findComment&comment=118700