### PR TITLE
Change text of ouroboros badges to better reflect level ranges

### DIFF
--- a/src/badge/ouroboros/adventurous.ts
+++ b/src/badge/ouroboros/adventurous.ts
@@ -10,7 +10,7 @@ export const Adventurous: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 20 and 24 while under a constant Debuff."},
     ],
-    acquisition: "Complete a level 20-24 Flashback story arc while debuffed.",
+    acquisition: "Complete a level 21-25 Flashback story arc while debuffed. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Adventurous Badge", href: "https://paragonwiki.com/wiki/Adventurous_Badge"}
     ],

--- a/src/badge/ouroboros/all-business.ts
+++ b/src/badge/ouroboros/all-business.ts
@@ -10,7 +10,7 @@ export const AllBusiness: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 25 and 29 while only using your Primary and Secondary powersets."},
     ],
-    acquisition: "Complete a level 25-29 Flashback arc using no pool powers.",
+    acquisition: "Complete a level 26-30 Flashback story arc using no pool powers. (Note: In game badge text is incorrect.)",
     links: [
         {title: "All Business Badge", href: "https://paragonwiki.com/wiki/All_Business_Badge"}
     ],

--- a/src/badge/ouroboros/all-for-one-one-for-all.ts
+++ b/src/badge/ouroboros/all-for-one-one-for-all.ts
@@ -10,7 +10,7 @@ export const AllForOneOneForAll: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback under the parameter of \"0 Defeats Allowed\" for the team."},
     ],
-    acquisition: "Complete a Flashback arc with zero defeats.",
+    acquisition: "Complete a Flashback story arc with zero defeats.",
     links: [
         {title: "All For One, One For All Badge", href: "https://paragonwiki.com/wiki/All_For_One,_One_For_All_Badge"}
     ],

--- a/src/badge/ouroboros/anemic.ts
+++ b/src/badge/ouroboros/anemic.ts
@@ -10,7 +10,7 @@ export const Anemic: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 20 and 24 while not gaining bonuses from slotted Enhancements."},
     ],
-    acquisition: "Complete a level 20-24 Flashback arc using no enhancements.",
+    acquisition: "Complete a level 21-25 Flashback story arc using no enhancements. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Anemic Badge", href: "https://paragonwiki.com/wiki/Anemic_Badge"}
     ],

--- a/src/badge/ouroboros/archetypical.ts
+++ b/src/badge/ouroboros/archetypical.ts
@@ -10,7 +10,7 @@ export const Archetypical: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 30 and 34 while only using your Primary and Secondary powersets."},
     ],
-    acquisition: "Complete a level 30-34 Flashback arc using no pool powers.",
+    acquisition: "Complete a level 31-35 Flashback story arc using no pool powers. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Archetypical Badge", href: "https://paragonwiki.com/wiki/Archetypical_Badge"}
     ],

--- a/src/badge/ouroboros/audacious.ts
+++ b/src/badge/ouroboros/audacious.ts
@@ -10,7 +10,7 @@ export const Audacious: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 1 and 15 while the enemies were Buffed."},
     ],
-    acquisition: "Complete a level 1-15 Flashback arc with enemies buffed.",
+    acquisition: "Complete a level 1-15 Flashback story arc with enemies buffed.",
     links: [
         {title: "Audacious Badge", href: "https://paragonwiki.com/wiki/Audacious_Badge"}
     ],

--- a/src/badge/ouroboros/barred.ts
+++ b/src/badge/ouroboros/barred.ts
@@ -10,7 +10,7 @@ export const Barred: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 25 and 29 while not using any Travel Power Pools."},
     ],
-    acquisition: "Complete a level 25-29 Flashback arc using no travel powers.",
+    acquisition: "Complete a level 26-30 Flashback story arc using no travel powers. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Barred Badge", href: "https://paragonwiki.com/wiki/Barred_Badge"}
     ],

--- a/src/badge/ouroboros/bold.ts
+++ b/src/badge/ouroboros/bold.ts
@@ -10,7 +10,7 @@ export const Bold: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 20 and 24 while the enemies were Buffed."},
     ],
-    acquisition: "Complete a level 20-24 Flashback arc with enemies buffed.",
+    acquisition: "Complete a level 21-25 Flashback story arc with enemies buffed. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Bold Badge", href: "https://paragonwiki.com/wiki/Bold_Badge"}
     ],

--- a/src/badge/ouroboros/bound.ts
+++ b/src/badge/ouroboros/bound.ts
@@ -10,7 +10,7 @@ export const Bound: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 35 and 39 while not using any Temporary Powers."},
     ],
-    acquisition: "Complete a level 35-39 Flashback arc using no temp powers.",
+    acquisition: "Complete a level 36-40 Flashback story arc using no temp powers. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Bound Badge", href: "https://paragonwiki.com/wiki/Bound_Badge"}
     ],

--- a/src/badge/ouroboros/bronze-medalist.ts
+++ b/src/badge/ouroboros/bronze-medalist.ts
@@ -10,7 +10,7 @@ export const BronzeMedalist: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback within the Bronze time allowed."},
     ],
-    acquisition: "Complete a Flashback arc in under 120 minutes.",
+    acquisition: "Complete a Flashback story arc in under 120 minutes.",
     links: [
         {title: "Bronze Medalist Badge", href: "https://paragonwiki.com/wiki/Bronze_Medalist_Badge"}
     ],

--- a/src/badge/ouroboros/capped.ts
+++ b/src/badge/ouroboros/capped.ts
@@ -10,7 +10,7 @@ export const Capped: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 20 and 24 while not using any Temporary Powers."},
     ],
-    acquisition: "Complete a level 20-24 Flashback arc using no temp powers.",
+    acquisition: "Complete a level 21-25 Flashback story arc using no temp powers. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Capped Badge", href: "https://paragonwiki.com/wiki/Capped_Badge"}
     ],

--- a/src/badge/ouroboros/cliche.ts
+++ b/src/badge/ouroboros/cliche.ts
@@ -10,7 +10,7 @@ export const Cliche: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 1 and 15 while not using Inspirations."},
     ],
-    acquisition: "Complete a level 1-15 Flashback arc using no inspirations.",
+    acquisition: "Complete a level 1-15 Flashback story arc using no inspirations.",
     links: [
         {title: "Cliche Badge", href: "https://paragonwiki.com/wiki/Cliche_Badge"}
     ],

--- a/src/badge/ouroboros/contributor.ts
+++ b/src/badge/ouroboros/contributor.ts
@@ -10,7 +10,7 @@ export const Contributor: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 1 and 15 while only using your Primary and Secondary powersets."},
     ],
-    acquisition: "Complete a level 1-15 Flashback arc using no pool powers.",
+    acquisition: "Complete a level 1-15 Flashback story arc using no pool powers.",
     links: [
         {title: "Contributor Badge", href: "https://paragonwiki.com/wiki/Contributor_Badge"}
     ],

--- a/src/badge/ouroboros/courageous.ts
+++ b/src/badge/ouroboros/courageous.ts
@@ -10,7 +10,7 @@ export const Courageous: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 15 and 19 while the enemies were Buffed."},
     ],
-    acquisition: "Complete a level 16-19 Flashback arc with enemies buffed.",
+    acquisition: "Complete a level 16-20 Flashback story arc with enemies buffed. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Courageous Badge", href: "https://paragonwiki.com/wiki/Courageous_Badge"}
     ],

--- a/src/badge/ouroboros/curtailed.ts
+++ b/src/badge/ouroboros/curtailed.ts
@@ -10,7 +10,7 @@ export const Curtailed: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 15 and 19 while not using any Temporary Powers."},
     ],
-    acquisition: "Complete a level 16-19 Flashback arc using no temp powers.",
+    acquisition: "Complete a level 16-20 Flashback story arc using no temp powers. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Curtailed Badge", href: "https://paragonwiki.com/wiki/Curtailed_Badge"}
     ],

--- a/src/badge/ouroboros/cut-off.ts
+++ b/src/badge/ouroboros/cut-off.ts
@@ -10,7 +10,7 @@ export const CutOff: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 40 and 44 while not using any Epic Power Pools."},
     ],
-    acquisition: "Complete a level 40-45 Flashback arc using no Ancillary powers.",
+    acquisition: "Complete a level 41-45 Flashback story arc using no Ancillary powers. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Cut-Off Badge", href: "https://paragonwiki.com/wiki/Cut-Off_Badge"}
     ],

--- a/src/badge/ouroboros/daredevil.ts
+++ b/src/badge/ouroboros/daredevil.ts
@@ -10,7 +10,7 @@ export const Daredevil: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 25 and 29 while under a constant Debuff."},
     ],
-    acquisition: "Complete a level 25-29 Flashback story arc while debuffed.",
+    acquisition: "Complete a level 26-30 Flashback story arc while debuffed.  (Note: In game badge text is incorrect.)",
     links: [
         {title: "Daredevil Badge", href: "https://paragonwiki.com/wiki/Daredevil_Badge"}
     ],

--- a/src/badge/ouroboros/debilitated.ts
+++ b/src/badge/ouroboros/debilitated.ts
@@ -10,7 +10,7 @@ export const Debilitated: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 15 and 19 while not gaining bonuses from slotted Enhancements."},
     ],
-    acquisition: "Complete a level 16-19 Flashback arc using no enhancements.",
+    acquisition: "Complete a level 16-20 Flashback story arc using no enhancements. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Debilitated Badge", href: "https://paragonwiki.com/wiki/Debilitated_Badge"}
     ],

--- a/src/badge/ouroboros/decreased.ts
+++ b/src/badge/ouroboros/decreased.ts
@@ -10,7 +10,7 @@ export const Decreased: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 35 and 39 while not gaining bonuses from slotted Enhancements."},
     ],
-    acquisition: "Complete a level 35-39 Flashback arc using no enhancements.",
+    acquisition: "Complete a level 36-40 Flashback story arc using no enhancements. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Decreased Badge", href: "https://paragonwiki.com/wiki/Decreased_Badge"}
     ],

--- a/src/badge/ouroboros/deflated.ts
+++ b/src/badge/ouroboros/deflated.ts
@@ -10,7 +10,7 @@ export const Deflated: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 30 and 34 while not gaining bonuses from slotted Enhancements."},
     ],
-    acquisition: "Complete a level 30-34 Flashback arc using no enhancements.",
+    acquisition: "Complete a level 31-35 Flashback story arc using no enhancements. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Deflated Badge", href: "https://paragonwiki.com/wiki/Deflated_Badge"}
     ],

--- a/src/badge/ouroboros/demarcated.ts
+++ b/src/badge/ouroboros/demarcated.ts
@@ -10,7 +10,7 @@ export const Demarcated: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 46 and 50 while not using any Temporary Powers."},
     ],
-    acquisition: "Complete a level 46-50 Flashback arc using no temp powers.",
+    acquisition: "Complete a level 46-50 Flashback story arc using no temp powers.",
     links: [
         {title: "Demarcated Badge", href: "https://paragonwiki.com/wiki/Demarcated_Badge"}
     ],

--- a/src/badge/ouroboros/desisted.ts
+++ b/src/badge/ouroboros/desisted.ts
@@ -10,7 +10,7 @@ export const Desisted: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 20 and 24 while not using any Travel Power Pools."},
     ],
-    acquisition: "Complete a level 20-24 Flashback arc using no travel powers.",
+    acquisition: "Complete a level 21-25 Flashback story arc using no travel powers. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Desisted Badge", href: "https://paragonwiki.com/wiki/Desisted_Badge"}
     ],

--- a/src/badge/ouroboros/devalued.ts
+++ b/src/badge/ouroboros/devalued.ts
@@ -10,7 +10,7 @@ export const Devalued: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 40 and 45 while not gaining bonuses from slotted Enhancements."},
     ],
-    acquisition: "Complete a level 40-45 Flashback arc using no enhancements.",
+    acquisition: "Complete a level 41-45 Flashback story arc using no enhancements. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Devalued Badge", href: "https://paragonwiki.com/wiki/Devalued_Badge"}
     ],

--- a/src/badge/ouroboros/diminished.ts
+++ b/src/badge/ouroboros/diminished.ts
@@ -10,7 +10,7 @@ export const Diminished: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 1 and 15 while not using any Temporary Powers."},
     ],
-    acquisition: "Complete a level 1-15 Flashback arc using no temp powers.",
+    acquisition: "Complete a level 1-15 Flashback story arc using no temp powers.",
     links: [
         {title: "Diminished Badge", href: "https://paragonwiki.com/wiki/Diminished_Badge"}
     ],

--- a/src/badge/ouroboros/divided-mastery.ts
+++ b/src/badge/ouroboros/divided-mastery.ts
@@ -10,7 +10,7 @@ export const DividedMastery: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback under the parameter of \"1 Defeat Allowed\" for the team."},
     ],
-    acquisition: "Complete a Flashback arc with one or fewer defeats.",
+    acquisition: "Complete a Flashback story arc with one or fewer defeats.",
     links: [
         {title: "Divided Mastery Badge", href: "https://paragonwiki.com/wiki/Divided_Mastery_Badge"}
     ],

--- a/src/badge/ouroboros/dull.ts
+++ b/src/badge/ouroboros/dull.ts
@@ -10,7 +10,7 @@ export const Dull: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 30 and 34 while not using Inspirations."},
     ],
-    acquisition: "Complete a level 30-34 Flashback arc using no inspirations.",
+    acquisition: "Complete a level 31-35 Flashback story arc using no inspirations. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Dull Badge", href: "https://paragonwiki.com/wiki/Dull_Badge"}
     ],

--- a/src/badge/ouroboros/fearless.ts
+++ b/src/badge/ouroboros/fearless.ts
@@ -10,7 +10,7 @@ export const Fearless: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 25 and 29 while the enemies were Buffed."},
     ],
-    acquisition: "Complete a level 25-29 Flashback arc with enemies buffed.",
+    acquisition: "Complete a level 26-30 Flashback story arc with enemies buffed. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Fearless Badge", href: "https://paragonwiki.com/wiki/Fearless_Badge"}
     ],

--- a/src/badge/ouroboros/flat.ts
+++ b/src/badge/ouroboros/flat.ts
@@ -10,7 +10,7 @@ export const Flat: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 20 and 24 while not using Inspirations."},
     ],
-    acquisition: "Complete a level 20-24 Flashback arc using no inspirations.",
+    acquisition: "Complete a level 21-25 Flashback story arc using no inspirations. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Flat Badge", href: "https://paragonwiki.com/wiki/Flat_Badge"}
     ],

--- a/src/badge/ouroboros/gold-medalist.ts
+++ b/src/badge/ouroboros/gold-medalist.ts
@@ -10,7 +10,7 @@ export const GoldMedalist: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback within the Gold time allowed."},
     ],
-    acquisition: "Complete a Flashback arc in under 30 minutes.",
+    acquisition: "Complete a Flashback story arc in under 30 minutes.",
     links: [
         {title: "Gold Medalist Badge", href: "https://paragonwiki.com/wiki/Gold_Medalist_Badge"}
     ],

--- a/src/badge/ouroboros/headstrong.ts
+++ b/src/badge/ouroboros/headstrong.ts
@@ -10,7 +10,7 @@ export const Headstrong: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 15 and 19 while under a constant Debuff."},
     ],
-    acquisition: "Complete a level 16-19 Flashback story arc while debuffed.",
+    acquisition: "Complete a level 16-20 Flashback story arc while debuffed.",
     links: [
         {title: "Headstrong Badge", href: "https://paragonwiki.com/wiki/Headstrong_Badge"}
     ],

--- a/src/badge/ouroboros/hindered.ts
+++ b/src/badge/ouroboros/hindered.ts
@@ -10,7 +10,7 @@ export const Hindered: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 30 and 34 while not using any Temporary Powers."},
     ],
-    acquisition: "Complete a level 30-34 Flashback arc using no temp powers.",
+    acquisition: "Complete a level 31-35 Flashback story arc using no temp powers. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Hindered Badge", href: "https://paragonwiki.com/wiki/Hindered_Badge"}
     ],

--- a/src/badge/ouroboros/indifferent.ts
+++ b/src/badge/ouroboros/indifferent.ts
@@ -10,7 +10,7 @@ export const Indifferent: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 40 and 45 while not using Inspirations."},
     ],
-    acquisition: "Complete a level 40-45 Flashback arc using no inspirations.",
+    acquisition: "Complete a level 41-45 Flashback story arc using no inspirations. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Indifferent Badge", href: "https://paragonwiki.com/wiki/Indifferent_Badge"}
     ],

--- a/src/badge/ouroboros/inhibited.ts
+++ b/src/badge/ouroboros/inhibited.ts
@@ -10,7 +10,7 @@ export const Inhibited: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 25 and 29 while not using any Temporary Powers."},
     ],
-    acquisition: "Complete a level 25-29 Flashback arc using no temp powers.",
+    acquisition: "Complete a level 26-30 Flashback story arc using no temp powers. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Inhibited Badge", href: "https://paragonwiki.com/wiki/Inhibited_Badge"}
     ],

--- a/src/badge/ouroboros/intrepid.ts
+++ b/src/badge/ouroboros/intrepid.ts
@@ -10,7 +10,7 @@ export const Intrepid: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 46 and 50 while the enemies were Buffed."},
     ],
-    acquisition: "Complete a level 46-50 Flashback arc with enemies buffed.",
+    acquisition: "Complete a level 46-50 Flashback story arc with enemies buffed.",
     links: [
         {title: "Intrepid Badge", href: "https://paragonwiki.com/wiki/Intrepid_Badge"}
     ],

--- a/src/badge/ouroboros/lessened.ts
+++ b/src/badge/ouroboros/lessened.ts
@@ -10,7 +10,7 @@ export const Lessened: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 1 and 15 while not gaining bonuses from slotted Enhancements."},
     ],
-    acquisition: "Complete a level 1-15 Flashback arc using no enhancements.",
+    acquisition: "Complete a level 1-15 Flashback story arc using no enhancements.",
     links: [
         {title: "Lessened Badge", href: "https://paragonwiki.com/wiki/Lessened_Badge"}
     ],

--- a/src/badge/ouroboros/limited.ts
+++ b/src/badge/ouroboros/limited.ts
@@ -10,7 +10,7 @@ export const Limited: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 40 and 45 while not using any Temporary Powers."},
     ],
-    acquisition: "Complete a level 40-45 Flashback arc using no temp powers.",
+    acquisition: "Complete a level 41-45 Flashback story arc using no temp powers. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Limited Badge", href: "https://paragonwiki.com/wiki/Limited_Badge"}
     ],

--- a/src/badge/ouroboros/lionhearted.ts
+++ b/src/badge/ouroboros/lionhearted.ts
@@ -10,7 +10,7 @@ export const Lionhearted: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 40 and 45 while the enemies were Buffed."},
     ],
-    acquisition: "Complete a level 40-45 Flashback arc with enemies buffed.",
+    acquisition: "Complete a level 41-45 Flashback story arc with enemies buffed. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Lionhearted Badge", href: "https://paragonwiki.com/wiki/Lionhearted_Badge"}
     ],

--- a/src/badge/ouroboros/marginalized.ts
+++ b/src/badge/ouroboros/marginalized.ts
@@ -10,7 +10,7 @@ export const Marginalized: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 46 and 50 while not using any Epic Power Pools."},
     ],
-    acquisition: "Complete a level 46-50 Flashback arc using no Ancillary powers.",
+    acquisition: "Complete a level 46-50 Flashback story arc using no Ancillary powers.",
     links: [
         {title: "Marginalized Badge", href: "https://paragonwiki.com/wiki/Marginalized_Badge"}
     ],

--- a/src/badge/ouroboros/missionary.ts
+++ b/src/badge/ouroboros/missionary.ts
@@ -10,7 +10,7 @@ export const Missionary: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 40 and 45 while only using your Primary and Secondary powersets."},
     ],
-    acquisition: "Complete a level 40-45 Flashback arc using no pool powers.",
+    acquisition: "Complete a level 41-45 Flashback story arc using no pool powers.",
     links: [
         {title: "Missionary Badge", href: "https://paragonwiki.com/wiki/Missionary_Badge"}
     ],

--- a/src/badge/ouroboros/obligated.ts
+++ b/src/badge/ouroboros/obligated.ts
@@ -10,7 +10,7 @@ export const Obligated: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 35 and 39 while only using your Primary and Secondary powersets."},
     ],
-    acquisition: "Complete a level 35-39 Flashback arc using no pool powers.",
+    acquisition: "Complete a level 36-40 Flashback story arc using no pool powers. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Obligated Badge", href: "https://paragonwiki.com/wiki/Obligated_Badge"}
     ],

--- a/src/badge/ouroboros/phoned-it-in.ts
+++ b/src/badge/ouroboros/phoned-it-in.ts
@@ -10,7 +10,7 @@ export const PhonedItIn: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 35 and 39 while not using Inspirations."},
     ],
-    acquisition: "Complete a level 35-39 Flashback arc using no inspirations.",
+    acquisition: "Complete a level 36-40 Flashback story arc using no inspirations. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Phoned it in Badge", href: "https://paragonwiki.com/wiki/Phoned_It_In_Badge"}
     ],

--- a/src/badge/ouroboros/professional.ts
+++ b/src/badge/ouroboros/professional.ts
@@ -10,7 +10,7 @@ export const Professional: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 20 and 24 while only using your Primary and Secondary powersets."},
     ],
-    acquisition: "Complete a level 20-24 Flashback arc using no pool powers.",
+    acquisition: "Complete a level 21-25 Flashback story arc using no pool powers. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Professional Badge", href: "https://paragonwiki.com/wiki/Professional_Badge"}
     ],

--- a/src/badge/ouroboros/proportional-supremacy.ts
+++ b/src/badge/ouroboros/proportional-supremacy.ts
@@ -10,7 +10,7 @@ export const ProportionalSupremacy: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback under the parameter of \"3 Defeats Allowed\" for the team."},
     ],
-    acquisition: "Complete a Flashback arc with three or fewer defeats.",
+    acquisition: "Complete a Flashback story arc with three or fewer defeats.",
     links: [
         {title: "Proportional Supremacy Badge", href: "https://paragonwiki.com/wiki/Proportional_Supremacy_Badge"}
     ],

--- a/src/badge/ouroboros/rash.ts
+++ b/src/badge/ouroboros/rash.ts
@@ -10,7 +10,7 @@ export const Rash: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 30 and 34 while under a constant Debuff."},
     ],
-    acquisition: "Complete a level 30-34 Flashback story arc while debuffed.",
+    acquisition: "Complete a level 31-35 Flashback story arc while debuffed. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Rash Badge", href: "https://paragonwiki.com/wiki/Rash_Badge"}
     ],

--- a/src/badge/ouroboros/reckless.ts
+++ b/src/badge/ouroboros/reckless.ts
@@ -10,7 +10,7 @@ export const Reckless: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 40 and 45 while under a constant Debuff."},
     ],
-    acquisition: "Complete a level 40-45 Flashback story arc while debuffed.",
+    acquisition: "Complete a level 41-45 Flashback story arc while debuffed. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Reckless Badge", href: "https://paragonwiki.com/wiki/Reckless_Badge"}
     ],

--- a/src/badge/ouroboros/refrained.ts
+++ b/src/badge/ouroboros/refrained.ts
@@ -10,7 +10,7 @@ export const Refrained: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 1 and 15 while not using any Travel Power Pools."},
     ],
-    acquisition: "Complete a level 1-15 Flashback arc using no travel powers.",
+    acquisition: "Complete a level 1-15 Flashback story arc using no travel powers.",
     links: [
         {title: "Refrained Badge", href: "https://paragonwiki.com/wiki/Refrained_Badge"}
     ],

--- a/src/badge/ouroboros/shared-victory.ts
+++ b/src/badge/ouroboros/shared-victory.ts
@@ -10,7 +10,7 @@ export const SharedVictory: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback under the parameter of \"5 Defeats Allowed\" for the team."},
     ],
-    acquisition: "Complete a Flashback arc with five or fewer defeats.",
+    acquisition: "Complete a Flashback story arc with five or fewer defeats.",
     links: [
         {title: "Shared Victory Badge", href: "https://paragonwiki.com/wiki/Shared_Victory_Badge"}
     ],

--- a/src/badge/ouroboros/shut-down.ts
+++ b/src/badge/ouroboros/shut-down.ts
@@ -10,7 +10,7 @@ export const ShutDown: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 15 and 19 while not using any Travel Power Pools."},
     ],
-    acquisition: "Complete a level 16-19 Flashback arc using no travel powers.",
+    acquisition: "Complete a level 16-20 Flashback story arc using no travel powers. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Shut Down Badge", href: "https://paragonwiki.com/wiki/Shut_Down_Badge"}
     ],

--- a/src/badge/ouroboros/silver-medalist.ts
+++ b/src/badge/ouroboros/silver-medalist.ts
@@ -10,7 +10,7 @@ export const SilverMedalist: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback within the Silver time allowed."},
     ],
-    acquisition: "Complete a Flashback arc in under 60 minutes.",
+    acquisition: "Complete a Flashback story arc in under 60 minutes.",
     links: [
         {title: "Silver Medalist Badge", href: "https://paragonwiki.com/wiki/Silver_Medalist_Badge"}
     ],

--- a/src/badge/ouroboros/stalled.ts
+++ b/src/badge/ouroboros/stalled.ts
@@ -10,7 +10,7 @@ export const Stalled: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 35 and 39 while not using any Travel Power Pools."},
     ],
-    acquisition: "Complete a level 35-39 Flashback arc using no travel powers.",
+    acquisition: "Complete a level 36-40 Flashback story arc using no travel powers.",
     links: [
         {title: "Stalled Badge", href: "https://paragonwiki.com/wiki/Stalled_Badge"}
     ],

--- a/src/badge/ouroboros/stalwart.ts
+++ b/src/badge/ouroboros/stalwart.ts
@@ -10,7 +10,7 @@ export const Stalwart: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 35 and 39 while the enemies were Buffed."},
     ],
-    acquisition: "Complete a level 35-39 Flashback arc with enemies buffed.",
+    acquisition: "Complete a level 36-40 Flashback story arc with enemies buffed. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Stalwart Badge", href: "https://paragonwiki.com/wiki/Stalwart_Badge"}
     ],

--- a/src/badge/ouroboros/stemmed.ts
+++ b/src/badge/ouroboros/stemmed.ts
@@ -10,7 +10,7 @@ export const Stemmed: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 40 and 45 while not using any Travel Power Pools."},
     ],
-    acquisition: "Complete a level 40-45 Flashback arc using no travel powers.",
+    acquisition: "Complete a level 41-45 Flashback story arc using no travel powers. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Stemmed Badge", href: "https://paragonwiki.com/wiki/Stalled_Badge"}
     ],

--- a/src/badge/ouroboros/still.ts
+++ b/src/badge/ouroboros/still.ts
@@ -10,7 +10,7 @@ export const Still: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 30 and 34 while not using any Travel Power Pools."},
     ],
-    acquisition: "Complete a level 30-34 Flashback arc using no travel powers.",
+    acquisition: "Complete a level 31-35 Flashback story arc using no travel powers. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Still Badge", href: "https://paragonwiki.com/wiki/Still_Badge"}
     ],

--- a/src/badge/ouroboros/suspended.ts
+++ b/src/badge/ouroboros/suspended.ts
@@ -10,7 +10,7 @@ export const Suspended: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 46 and 50 while not using any Travel Power Pools."},
     ],
-    acquisition: "Complete a level 46-50 Flashback arc using no travel powers.",
+    acquisition: "Complete a level 46-50 Flashback story arc using no travel powers.",
     links: [
         {title: "Suspended Badge", href: "https://paragonwiki.com/wiki/Suspended_Badge"}
     ],

--- a/src/badge/ouroboros/undertaker.ts
+++ b/src/badge/ouroboros/undertaker.ts
@@ -10,7 +10,7 @@ export const Undertaker: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 46 and 50 while only using your Primary and Secondary powersets."},
     ],
-    acquisition: "Complete a level 46-50 Flashback arc using no pool powers.",
+    acquisition: "Complete a level 46-50 Flashback story arc using no pool powers.",
     links: [
         {title: "Undertaker Badge", href: "https://paragonwiki.com/wiki/Undertaker_Badge"}
     ],

--- a/src/badge/ouroboros/unenhanced.ts
+++ b/src/badge/ouroboros/unenhanced.ts
@@ -10,7 +10,7 @@ export const Unenhanced: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 46 and 50 while not gaining bonuses from slotted Enhancements."},
     ],
-    acquisition: "Complete a level 46-50 Flashback arc using no enhancements.",
+    acquisition: "Complete a level 46-50 Flashback story arc using no enhancements.",
     links: [
         {title: "Unenhanced Badge", href: "https://paragonwiki.com/wiki/Unenhanced_Badge"}
     ],

--- a/src/badge/ouroboros/unimaginative.ts
+++ b/src/badge/ouroboros/unimaginative.ts
@@ -10,7 +10,7 @@ export const Unimaginative: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 15 and 19 while not using Inspirations."},
     ],
-    acquisition: "Complete a level 16-19 Flashback arc using no inspirations.",
+    acquisition: "Complete a level 16-20 Flashback story arc using no inspirations. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Unimaginative Badge", href: "https://paragonwiki.com/wiki/Unimaginative_Badge"}
     ],

--- a/src/badge/ouroboros/uninspired.ts
+++ b/src/badge/ouroboros/uninspired.ts
@@ -10,7 +10,7 @@ export const Uninspired: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 46 and 50 while not using Inspirations."},
     ],
-    acquisition: "Complete a level 46-50 Flashback arc using no inspirations.",
+    acquisition: "Complete a level 46-50 Flashback story arc using no inspirations.",
     links: [
         {title: "Uninspired Badge", href: "https://paragonwiki.com/wiki/Uninspired_Badge"}
     ],

--- a/src/badge/ouroboros/unoriginal.ts
+++ b/src/badge/ouroboros/unoriginal.ts
@@ -10,7 +10,7 @@ export const Unoriginal: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 25 and 29 while not using Inspirations."},
     ],
-    acquisition: "Complete a level 25-29 Flashback arc using no inspirations.",
+    acquisition: "Complete a level 26-30 Flashback story arc using no inspirations. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Unoriginal Badge", href: "https://paragonwiki.com/wiki/Unoriginal_Badge"}
     ],

--- a/src/badge/ouroboros/valiant.ts
+++ b/src/badge/ouroboros/valiant.ts
@@ -10,7 +10,7 @@ export const Valiant: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 30 and 34 while the enemies were Buffed."},
     ],
-    acquisition: "Complete a level 30-34 Flashback arc with enemies buffed.",
+    acquisition: "Complete a level 31-35 Flashback story arc with enemies buffed. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Valiant Badge", href: "https://paragonwiki.com/wiki/Valiant_Badge"}
     ],

--- a/src/badge/ouroboros/venturesome.ts
+++ b/src/badge/ouroboros/venturesome.ts
@@ -10,7 +10,7 @@ export const Venturesome: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 35 and 39 while under a constant Debuff."},
     ],
-    acquisition: "Complete a level 35-39 Flashback story arc while debuffed.",
+    acquisition: "Complete a level 36-40 Flashback story arc while debuffed. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Venturesome Badge", href: "https://paragonwiki.com/wiki/Venturesome_Badge"}
     ],

--- a/src/badge/ouroboros/vocational.ts
+++ b/src/badge/ouroboros/vocational.ts
@@ -10,7 +10,7 @@ export const Vocational: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 15 and 19 while only using your Primary and Secondary powersets."},
     ],
-    acquisition: "Complete a level 16-19 Flashback arc using no pool powers.",
+    acquisition: "Complete a level 16-20 Flashback story arc using no pool powers. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Vocational Badge", href: "https://paragonwiki.com/wiki/Vocational_Badge"}
     ],

--- a/src/badge/ouroboros/weakened.ts
+++ b/src/badge/ouroboros/weakened.ts
@@ -10,7 +10,7 @@ export const Weakened: IBadgeData = {
     badgeText: [
         {value: "You have completed a Task Force/Flashback between level 25 and 29 while not gaining bonuses from slotted Enhancements."},
     ],
-    acquisition: "Complete a level 25-29 Flashback arc using no enhancements.",
+    acquisition: "Complete a level 26-30 Flashback story arc using no enhancements. (Note: In game badge text is incorrect.)",
     links: [
         {title: "Weakened Badge", href: "https://paragonwiki.com/wiki/Weakened_Badge"}
     ],


### PR DESCRIPTION
Based on testing, it seems like all the Ouroboros ranges start at 5n+1 and end at 5n. That said, this will likely never be 100% accurate as there are some that work for a completely different level range (there's a level 25 villain arc that awards the 1-15 badges for instance).

Also, standardized some text to make the descriptions uniform.

Resolves #2 