### PR TITLE
Update former-servant-of-recluse.ts

### DIFF
--- a/src/badge/accomplishment/former-servant-of-recluse.ts
+++ b/src/badge/accomplishment/former-servant-of-recluse.ts
@@ -19,6 +19,6 @@ export const FormerServantOfRecluse: IBadgeData = {
         {title: "Servant of Recluse Badge", href: "https://paragonwiki.com/wiki/Servant_of_Recluse_Badge"}
     ],
     icons: [
-        {value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/former-servant-of-recluse.png"}
+        {value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accolade/recluses-betrayer.png"}
     ],
 };


### PR DESCRIPTION
Updated this badge to use the correct icon (which is the icon for the 'Recluse's Betrayer' accolade badge.

I also sent a PM on the homecoming forums with a perhaps better way to fix this, so be sure to check your Homecoming PMs before accepting this request.