### PR TITLE
Correct number of crafts for Rebuilder, 12 (6+6)

### DIFF
--- a/src/badge/invention/rebuilder.ts
+++ b/src/badge/invention/rebuilder.ts
@@ -26,7 +26,6 @@ export const Rebuilder: IBadgeData = {
             inventionLevel: 30,
             inventionTypes: [EnhancementCategory.HEALING],
             count: 6
-        },
-        {key: "c", type: BadgePartialType.INVENTION_PLUS_ONE}
+        }
     ]
 };


### PR DESCRIPTION
Heal and defense invention badges use the same numbers. Rebuilder, like Protector, is 12 (6+6), not 13 (6+6+1). (Paragon Wiki has the wrong number.)