### PR TITLE
Merged pull request (#1)

### DIFF
--- a/src/badge/accomplishment/chameleon.ts
+++ b/src/badge/accomplishment/chameleon.ts
@@ -1,4 +1,6 @@
 import {ALIGNMENT_HERO, BadgeType, IBadgeData} from "coh-content-db";
+import {IndependencePort} from "../../map/independence-port";
+import {TalosIsland} from "../../map/talos-island";
 
 export const Chameleon: IBadgeData = {
     type: BadgeType.ACCOMPLISHMENT,
@@ -10,7 +12,8 @@ export const Chameleon: IBadgeData = {
     alignment: ALIGNMENT_HERO,
     badgeText: [{value: `You infiltrated the Freakshow and recovered the stolen Chameleon Suit.`}],
     icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/accomp_stature_05.png"}],
-    acquisition: `Complete the task set 'The Chameleon Suit' which is available via the 'Infiltrate the Freakshow and recover the stolen Chameleon Suit' mission from level 20-24 contacts Andrew Fiore, Jake Kim, Lt. Col. Hugh McDougal, or Wilma Peterson. Also available via Ouroboros, Level 20-24, mission 0.12 'The Chameleon Suit'.`,
+    acquisition: `Complete the task set 'The Chameleon Suit'`,
+    notes: `The task set 'The Chameleon Suit' begins with the 'Infiltrate the Freakshow and recover the stolen Chameleon Suit' mission from any one of the level 20-24 contacts Andrew Fiore or Lt. Col. Hugh McDougal in [map:${TalosIsland.key}], or Jake Kim or Wilma Peterson in [map:${IndependencePort.key}]. It is also available via Ouroboros, level 20-24, mission 0.12 'The Chameleon Suit'.`,
     links: [
         {title: "Chameleon Badge", href: "https://paragonwiki.com/wiki/Chameleon_Badge"}
     ],

--- a/src/badge/accomplishment/do-no-harm.ts
+++ b/src/badge/accomplishment/do-no-harm.ts
@@ -1,4 +1,5 @@
-import {ALIGNMENT_ANY, BadgeType, IBadgeData} from "coh-content-db";
+import {ALIGNMENT_HERO, BadgeType, IBadgeData} from "coh-content-db";
+import {Brickstown} from "../../map/brickstown";
 
 export const DoNoHarm: IBadgeData = {
     type: BadgeType.ACCOMPLISHMENT,
@@ -7,10 +8,11 @@ export const DoNoHarm: IBadgeData = {
     names: [
         {value: "Do No Harm"}
     ],
-    alignment: ALIGNMENT_ANY,
+    alignment: ALIGNMENT_HERO,
     badgeText: [{value: `You have delivered medical supplies to the Rikti.`}],
     icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/accomp_stature_11.png"}],
-    acquisition: "Complete the task set `Hippocratic Oath`.",
+    acquisition: `Complete the task set 'Hippocratic Oath'.`,
+    notes: `The task set 'Hippocratic Oath' begins with the 'Rescue the doctors from the Rikti' mission from level 35-39 contact Steven Sheridan in [map:${Brickstown.key}]. It is also available via Ouroboros, level 35-39, mission 0.35 'Hippocratic Oath'.`,
     links: [
         {title: "Do No Harm Badge", href: "https://paragonwiki.com/wiki/Do_No_Harm_Badge"}
     ],

--- a/src/badge/accomplishment/true-nemesis.ts
+++ b/src/badge/accomplishment/true-nemesis.ts
@@ -1,4 +1,5 @@
-import {ALIGNMENT_ANY, BadgeType, IBadgeData} from "coh-content-db";
+import {ALIGNMENT_HERO, BadgeType, IBadgeData} from "coh-content-db";
+import {FoundersFalls} from "../../map/founders-falls";
 
 export const TrueNemesis: IBadgeData = {
     type: BadgeType.ACCOMPLISHMENT,
@@ -7,10 +8,11 @@ export const TrueNemesis: IBadgeData = {
     names: [
         {value: "True Nemesis"}
     ],
-    alignment: ALIGNMENT_ANY,
+    alignment: ALIGNMENT_HERO,
     badgeText: [{value: `You have stopped Nemesis Rex's incursion into Primal Earth.`}],
     icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/accomp_stature_13.png"}],
-    acquisition: "Complete the task set `Nemesis Rex`.",
+    acquisition: `Complete the task set 'Nemesis Rex'.`,
+    notes: `The task set 'Nemesis Rex' begins with the 'Stop the battle between Nemesis Army factions and make sure no innocents get hurt' mission from level 40-44 contact Maxwell Christopher in [map:${FoundersFalls.key}]. It is also available via Ouroboros, level 40-49, mission 1.07 'Nemesis Rex'.`,
     links: [
         {title: "True Nemesis Badge", href: "https://paragonwiki.com/wiki/True_Nemesis_Badge"}
     ],

--- a/src/badge/achievement/adamant.ts
+++ b/src/badge/achievement/adamant.ts
@@ -4,6 +4,7 @@ export const Adamant: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "adamant",
     setTitleId: 10,
+    setTitleIdPraetorian: 1676,
     names: [
         {type: Alternate.H, value: "Adamant"},
         {type: Alternate.MV, value: "Ironman"},

--- a/src/badge/achievement/adventurer.ts
+++ b/src/badge/achievement/adventurer.ts
@@ -4,6 +4,7 @@ export const Adventurer: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "adventurer",
     setTitleId: 1581,
+    setTitleIdPraetorian: 1666,
     names: [
         {value: "Adventurer"},
         {type: Alternate.P, value: "Doer"}

--- a/src/badge/achievement/advisor.ts
+++ b/src/badge/achievement/advisor.ts
@@ -4,6 +4,7 @@ export const Advisor: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "advisor",
     setTitleId: 12,
+    setTitleIdPraetorian: 1705,
     names: [
         {type: Alternate.H, value: "Advisor"},
         {type: Alternate.V, value: "Comrade"},

--- a/src/badge/achievement/caged.ts
+++ b/src/badge/achievement/caged.ts
@@ -4,6 +4,7 @@ export const Caged: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "caged",
     setTitleId: 240,
+    setTitleIdPraetorian: 1697,
     names: [
         {value: "Caged"},
         {type: Alternate.P, value: "Can't Do That"}

--- a/src/badge/achievement/celebrity.ts
+++ b/src/badge/achievement/celebrity.ts
@@ -4,6 +4,7 @@ export const Celebrity: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "celebrity",
     setTitleId: 5,
+    setTitleIdPraetorian: 1699,
     names: [
         {type: Alternate.H, value: "Celebrity"},
         {type: Alternate.V, value: "Bling"},

--- a/src/badge/achievement/collector.ts
+++ b/src/badge/achievement/collector.ts
@@ -4,6 +4,7 @@ export const Collector: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "collector",
     setTitleId: 27,
+    setTitleIdPraetorian: 1661,
     names: [
         {type: Alternate.H, value: "Collector"},
         {type: Alternate.V, value: "Native"},

--- a/src/badge/achievement/confined.ts
+++ b/src/badge/achievement/confined.ts
@@ -4,6 +4,7 @@ export const Confined: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "confined",
     setTitleId: 239,
+    setTitleIdPraetorian: 1696,
     names: [
         {value: "Confined"},
         {type: Alternate.P, value: "Stuck"}

--- a/src/badge/achievement/deathless.ts
+++ b/src/badge/achievement/deathless.ts
@@ -4,6 +4,7 @@ export const Deathless: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "deathless",
     setTitleId: 233,
+    setTitleIdPraetorian: 1684,
     names: [
         {value: "Deathless"},
         {type: Alternate.P, value: "Impulsive"}

--- a/src/badge/achievement/defender-of-truth.ts
+++ b/src/badge/achievement/defender-of-truth.ts
@@ -4,6 +4,7 @@ export const DefenderOfTruth: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "defender-of-truth",
     setTitleId: 23,
+    setTitleIdPraetorian: 1671,
     names: [
         {type: Alternate.H, value: "Defender of Truth"},
         {type: Alternate.MV, value: "Wiseguy"},

--- a/src/badge/achievement/doctor.ts
+++ b/src/badge/achievement/doctor.ts
@@ -4,6 +4,7 @@ export const Doctor: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "doctor",
     setTitleId: 4,
+    setTitleIdPraetorian: 1689,
     names: [
         {type: Alternate.H, value: "Doctor"},
         {type: Alternate.V, value: "Mad Scientist"},

--- a/src/badge/achievement/empath.ts
+++ b/src/badge/achievement/empath.ts
@@ -4,6 +4,7 @@ export const Empath: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "empath",
     setTitleId: 238,
+    setTitleIdPraetorian: 1692,
     names: [
         {value: "Empath"},
         {type: Alternate.P, value: "Death's Jailer"}

--- a/src/badge/achievement/entangled.ts
+++ b/src/badge/achievement/entangled.ts
@@ -4,6 +4,7 @@ export const Entangled: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "entangled",
     setTitleId: 19,
+    setTitleIdPraetorian: 1694,
     names: [
         {type: Alternate.H, value: "Entangled"},
         {type: Alternate.V, value: "Sleepy"},

--- a/src/badge/achievement/epitome.ts
+++ b/src/badge/achievement/epitome.ts
@@ -4,6 +4,7 @@ export const Epitome: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "epitome",
     setTitleId: 246,
+    setTitleIdPraetorian: 1709,
     names: [
         {value: "Epitome"},
         {type: Alternate.P, value: "Philosopher"}

--- a/src/badge/achievement/exalted.ts
+++ b/src/badge/achievement/exalted.ts
@@ -4,6 +4,7 @@ export const Exalted: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "exalted",
     setTitleId: 235,
+    setTitleIdPraetorian: 1686,
     names: [
         {value: "Exalted"},
         {type: Alternate.P, value: "Infinite Lives"}

--- a/src/badge/achievement/explorer.ts
+++ b/src/badge/achievement/explorer.ts
@@ -4,6 +4,7 @@ export const Explorer: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "explorer",
     setTitleId: 28,
+    setTitleIdPraetorian: 1662,
     names: [
         {type: Alternate.H, value: "Explorer"},
         {type: Alternate.V, value: "Obsessed"},

--- a/src/badge/achievement/guardian-of-forever.ts
+++ b/src/badge/achievement/guardian-of-forever.ts
@@ -1,4 +1,5 @@
-import {ALIGNMENT_ANY, BadgeType, IBadgeData} from "coh-content-db";
+import {ALIGNMENT_HERO, BadgeType, IBadgeData} from "coh-content-db";
+import {SteelCanyon} from "../../map/steel-canyon";
 
 export const GuardianOfForever: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
@@ -7,10 +8,20 @@ export const GuardianOfForever: IBadgeData = {
     names: [
         {value: "Guardian of Forever"}
     ],
-    alignment: ALIGNMENT_ANY,
+    alignment: ALIGNMENT_HERO,
     badgeText: [{value: `You used the Pillar of Ice and Flame to cheat death and recruit a new member for Ouroboros.`}],
     icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/guardian-of-forever.png"}],
     acquisition: "Recruit a new member into Ouroboros.",
+    notes: `SPOILER WARNING: The notes below contain story spoilers.
+
+Complete the 'Collateral Damage' story arc, available either via Laura Lockhart in [map:${SteelCanyon.key}] or Ouroboros, level 20-24, mission 22.01 'Collateral Damage'
+ - Be sure to defeat all the enemies at the end of the second mission in less than 3 minutes to earn the Steel Savior badge
+
+Repeat the story arc via Ouroboros
+ - In the first mission, find a glowing crate and read the clue contained within
+ - Following the first mission, speak to Laura Lockhart but DO NOT enter the second mission
+ - Before entering the second mission, travel to Ouroboros and speak to Mender Valen
+ - Agree to rescue Laura according to Mender Valen's instructions, and if successful, the Guardian of Forever badge will be awarded during the fifth mission`,
     links: [
         {title: "Guardian of Forever Badge", href: "https://paragonwiki.com/wiki/Guardian_of_Forever_Badge"}
     ],

--- a/src/badge/achievement/guide.ts
+++ b/src/badge/achievement/guide.ts
@@ -4,6 +4,7 @@ export const Guide: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "guide",
     setTitleId: 13,
+    setTitleIdPraetorian: 1706,
     names: [
         {type: Alternate.H, value: "Guide"},
         {type: Alternate.V, value: "Drill Instructor"},

--- a/src/badge/achievement/hero-of-the-city.ts
+++ b/src/badge/achievement/hero-of-the-city.ts
@@ -4,6 +4,7 @@ export const HeroOfTheCity: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "hero-of-the-city",
     setTitleId: 25,
+    setTitleIdPraetorian: 1673,
     names: [
         {type: Alternate.H, value: "Hero of the City"},
         {type: Alternate.V, value: "Made"},

--- a/src/badge/achievement/immortal.ts
+++ b/src/badge/achievement/immortal.ts
@@ -4,6 +4,7 @@ export const Immortal: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "immortal",
     setTitleId: 232,
+    setTitleIdPraetorian: 1680,
     names: [
         {value: "Immortal"},
         {type: Alternate.P, value: "Challenger of Gods"}

--- a/src/badge/achievement/imprisoned.ts
+++ b/src/badge/achievement/imprisoned.ts
@@ -4,6 +4,7 @@ export const Imprisoned: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "imprisoned",
     setTitleId: 20,
+    setTitleIdPraetorian: 1695,
     names: [
         {type: Alternate.H, value: "Imprisoned"},
         {type: Alternate.V, value: "Dazed and Confused"},

--- a/src/badge/achievement/indestructible.ts
+++ b/src/badge/achievement/indestructible.ts
@@ -4,6 +4,7 @@ export const Indestructible: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "indestructible",
     setTitleId: 9,
+    setTitleIdPraetorian: 1675,
     names: [
         {type: Alternate.H, value: "Indestructible"},
         {type: Alternate.V, value: "Hard Case"},

--- a/src/badge/achievement/invulnerable.ts
+++ b/src/badge/achievement/invulnerable.ts
@@ -4,6 +4,7 @@ export const Invulnerable: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "invulnerable",
     setTitleId: 231,
+    setTitleIdPraetorian: 1679,
     names: [
         {value: "Invulnerable"},
         {type: Alternate.P, value: "Marvel of Modern Medicine"}

--- a/src/badge/achievement/jailed.ts
+++ b/src/badge/achievement/jailed.ts
@@ -4,6 +4,7 @@ export const Jailed: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "jailed",
     setTitleId: 241,
+    setTitleIdPraetorian: 1698,
     names: [
         {value: "Jailed"},
         {type: Alternate.P, value: "Lagged"}

--- a/src/badge/achievement/justice-incarnate.ts
+++ b/src/badge/achievement/justice-incarnate.ts
@@ -4,6 +4,7 @@ export const JusticeIncarnate: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "justice-incarnate",
     setTitleId: 24,
+    setTitleIdPraetorian: 1672,
     names: [
         {type: Alternate.H, value: "Justice Incarnate"},
         {type: Alternate.V, value: "Captain"},

--- a/src/badge/achievement/keeper-of-peace.ts
+++ b/src/badge/achievement/keeper-of-peace.ts
@@ -4,6 +4,7 @@ export const KeeperOfPeace: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "keeper-of-peace",
     setTitleId: 22,
+    setTitleIdPraetorian: 1670,
     names: [
         {type: Alternate.H, value: "Keeper of Peace"},
         {type: Alternate.V, value: "Insider"},

--- a/src/badge/achievement/leader.ts
+++ b/src/badge/achievement/leader.ts
@@ -4,6 +4,7 @@ export const Leader: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "leader",
     setTitleId: 244,
+    setTitleIdPraetorian: 1704,
     names: [
         {value: "Leader"},
         {type: Alternate.P, value: "The Chosen One"}

--- a/src/badge/achievement/medic.ts
+++ b/src/badge/achievement/medic.ts
@@ -4,6 +4,7 @@ export const Medic: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "medic",
     setTitleId: 2,
+    setTitleIdPraetorian: 1687,
     names: [
         {type: Alternate.H, value: "Medic"},
         {type: Alternate.V, value: "Fixer"},

--- a/src/badge/achievement/medical-specialist.ts
+++ b/src/badge/achievement/medical-specialist.ts
@@ -4,6 +4,7 @@ export const MedicalSpecialist: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "medical-specialist",
     setTitleId: 236,
+    setTitleIdPraetorian: 1690,
     names: [
         {value: "Medical Specialist"},
         {type: Alternate.P, value: "To the Rescue"}

--- a/src/badge/achievement/medicine-man.ts
+++ b/src/badge/achievement/medicine-man.ts
@@ -4,6 +4,7 @@ export const MedicineMan: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "medicine-man",
     setTitleId: 237,
+    setTitleIdPraetorian: 1691,
     names: [
         {type: Alternate.MH, value: "Medicine Man"},
         {type: Alternate.FH, value: "Medicine Woman"},

--- a/src/badge/achievement/nigh-indestructible.ts
+++ b/src/badge/achievement/nigh-indestructible.ts
@@ -4,6 +4,7 @@ export const NighIndestructible: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "nigh-indestructible",
     setTitleId: 230,
+    setTitleIdPraetorian: 1678,
     names: [
         {value: "Nigh Indestructible"},
         {type: Alternate.P, value: "Concussed"}

--- a/src/badge/achievement/paradigm.ts
+++ b/src/badge/achievement/paradigm.ts
@@ -4,6 +4,7 @@ export const Paradigm: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "paradigm",
     setTitleId: 247,
+    setTitleIdPraetorian: 1710,
     names: [
         {value: "Paradigm"},
         {type: Alternate.P, value: "Old-Timer"}

--- a/src/badge/achievement/paragon.ts
+++ b/src/badge/achievement/paragon.ts
@@ -4,6 +4,7 @@ export const Paragon: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "paragon",
     setTitleId: 14,
+    setTitleIdPraetorian: 1707,
     names: [
         {type: Alternate.H, value: "Paragon"},
         {type: Alternate.V, value: "Svengali"},

--- a/src/badge/achievement/pathfinder.ts
+++ b/src/badge/achievement/pathfinder.ts
@@ -4,6 +4,7 @@ export const Pathfinder: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "pathfinder",
     setTitleId: 29,
+    setTitleIdPraetorian: 1663,
     names: [
         {value: "Pathfinder"},
         {type: Alternate.MP, value: "Knows He Knows Not"},

--- a/src/badge/achievement/popular.ts
+++ b/src/badge/achievement/popular.ts
@@ -4,6 +4,7 @@ export const Popular: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "popular",
     setTitleId: 243,
+    setTitleIdPraetorian: 1703,
     names: [
         {value: "Popular"},
         {type: Alternate.P, value: "Living Legend"}

--- a/src/badge/achievement/protector-of-innocents.ts
+++ b/src/badge/achievement/protector-of-innocents.ts
@@ -4,6 +4,7 @@ export const ProtectorOfInnocents: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "protector-of-innocents",
     setTitleId: 21,
+    setTitleIdPraetorian: 1669,
     names: [
         {type: Alternate.H, value: "Protector of Innocents"},
         {type: Alternate.V, value: "Soldier"},

--- a/src/badge/achievement/questing.ts
+++ b/src/badge/achievement/questing.ts
@@ -4,6 +4,7 @@ export const Questing: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "questing",
     setTitleId: 1582,
+    setTitleIdPraetorian: 1667,
     names: [
         {value: "Questing"},
         {type: Alternate.P, value: "Prepared"}

--- a/src/badge/achievement/restrained.ts
+++ b/src/badge/achievement/restrained.ts
@@ -4,6 +4,7 @@ export const Restrained: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "restrained",
     setTitleId: 18,
+    setTitleIdPraetorian: 1693,
     names: [
         {type: Alternate.H, value: "Restrained"},
         {type: Alternate.V, value: "Slacker"},

--- a/src/badge/achievement/role-model.ts
+++ b/src/badge/achievement/role-model.ts
@@ -4,6 +4,7 @@ export const RoleModel: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "role-model",
     setTitleId: 245,
+    setTitleIdPraetorian: 1708,
     names: [
         {value: "Role Model"},
         {type: Alternate.P, value: "Dean of Hard Knocks"}

--- a/src/badge/achievement/seeker.ts
+++ b/src/badge/achievement/seeker.ts
@@ -4,6 +4,7 @@ export const Seeker: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "seeker",
     setTitleId: 1580,
+    setTitleIdPraetorian: 1665,
     names: [
         {value: "Seeker"},
         {type: Alternate.P, value: "Overachiever"}

--- a/src/badge/achievement/sensation.ts
+++ b/src/badge/achievement/sensation.ts
@@ -4,6 +4,7 @@ export const Sensation: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "sensation",
     setTitleId: 6,
+    setTitleIdPraetorian: 1700,
     names: [
         {type: Alternate.H, value: "Sensation"},
         {type: Alternate.MV, value: "Mr. Big"},

--- a/src/badge/achievement/superstar.ts
+++ b/src/badge/achievement/superstar.ts
@@ -4,6 +4,7 @@ export const Superstar: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "superstar",
     setTitleId: 7,
+    setTitleIdPraetorian: 1701,
     names: [
         {type: Alternate.H, value: "Superstar"},
         {type: Alternate.V, value: "Midas Touch"},

--- a/src/badge/achievement/surgeon.ts
+++ b/src/badge/achievement/surgeon.ts
@@ -4,6 +4,7 @@ export const Surgeon: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "surgeon",
     setTitleId: 3,
+    setTitleIdPraetorian: 1688,
     names: [
         {type: Alternate.H, value: "Surgeon"},
         {type: Alternate.V, value: "Doc"},

--- a/src/badge/achievement/the-unbroken-spirit.ts
+++ b/src/badge/achievement/the-unbroken-spirit.ts
@@ -4,6 +4,7 @@ export const TheUnbrokenSpirit: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "the-unbroken-spirit",
     setTitleId: 17,
+    setTitleIdPraetorian: 1683,
     names: [
         {value: "The Unbroken Spirit"},
         {type: Alternate.P, value: "Undaunted"}

--- a/src/badge/achievement/the-unwavering.ts
+++ b/src/badge/achievement/the-unwavering.ts
@@ -4,6 +4,7 @@ export const TheUnwavering: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "the-unwavering",
     setTitleId: 15,
+    setTitleIdPraetorian: 1681,
     names: [
         {type: Alternate.H, value: "The Unwavering"},
         {type: Alternate.V, value: "Punch Drunk"},

--- a/src/badge/achievement/the-unyielding.ts
+++ b/src/badge/achievement/the-unyielding.ts
@@ -4,6 +4,7 @@ export const TheUnyielding: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "the-unyielding",
     setTitleId: 16,
+    setTitleIdPraetorian: 1682,
     names: [
         {type: Alternate.H, value: "The Unyielding"},
         {type: Alternate.V, value: "Unbroken"},

--- a/src/badge/achievement/tough.ts
+++ b/src/badge/achievement/tough.ts
@@ -4,6 +4,7 @@ export const Tough: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "tough",
     setTitleId: 8,
+    setTitleIdPraetorian: 1674,
     names: [
         {type: Alternate.H, value: "Tough"},
         {type: Alternate.V, value: "Stoic"},

--- a/src/badge/achievement/tourist.ts
+++ b/src/badge/achievement/tourist.ts
@@ -4,6 +4,7 @@ export const Tourist: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "tourist",
     setTitleId: 26,
+    setTitleIdPraetorian: 1660,
     names: [
         {type: Alternate.H, value: "Tourist"},
         {type: Alternate.V, value: "Visitor"},

--- a/src/badge/achievement/trailblazer.ts
+++ b/src/badge/achievement/trailblazer.ts
@@ -4,6 +4,7 @@ export const Trailblazer: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "trailblazer",
     setTitleId: 407,
+    setTitleIdPraetorian: 1664,
     names: [
         {value: "Trailblazer"},
         {type: Alternate.P, value: "Emissary"}

--- a/src/badge/achievement/trendsetter.ts
+++ b/src/badge/achievement/trendsetter.ts
@@ -4,6 +4,7 @@ export const Trendsetter: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "trendsetter",
     setTitleId: 242,
+    setTitleIdPraetorian: 1702,
     names: [
         {value: "Trendsetter"},
         {type: Alternate.P, value: "Renowned"}

--- a/src/badge/achievement/unbreakable.ts
+++ b/src/badge/achievement/unbreakable.ts
@@ -4,6 +4,7 @@ export const Unbreakable: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "unbreakable",
     setTitleId: 11,
+    setTitleIdPraetorian: 1677,
     names: [
         {value: "Unbreakable"},
         {type: Alternate.P, value: "Iron Willed"}

--- a/src/badge/achievement/undying.ts
+++ b/src/badge/achievement/undying.ts
@@ -4,6 +4,7 @@ export const Undying: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "undying",
     setTitleId: 234,
+    setTitleIdPraetorian: 1685,
     names: [
         {value: "Undying"},
         {type: Alternate.P, value: "Never Learns"}

--- a/src/badge/achievement/voyager.ts
+++ b/src/badge/achievement/voyager.ts
@@ -4,6 +4,7 @@ export const Voyager: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
     key: "voyager",
     setTitleId: 1583,
+    setTitleIdPraetorian: 1668,
     names: [
         {value: "Voyager"},
         {type: Alternate.P, value: "No Road Not Taken"}

--- a/src/badge/event/evils-resident.ts
+++ b/src/badge/event/evils-resident.ts
@@ -9,9 +9,9 @@ export const EvilsResident: IBadgeData = {
     ],
     alignment: ALIGNMENT_ANY,
     badgeText: [
-        {value: "You've taken down 25 Zombie Minions, showing you have Glimpsed the Abyss."},
+        {value: "You've defeated 25 Zombie Bosses, making your place of occupation a Home of the Dead."},
     ],
-    acquisition: "Defeat 25 Zombie minions during Zombie Apocalypses.",
+    acquisition: "Defeat 25 Zombie bosses during Zombie Apocalypses.",
     links: [
         {title: "Evil's Resident Badge", href: "https://paragonwiki.com/wiki/Evil%27s_Resident_Badge"}
     ],

--- a/src/badge/event/safety-in-numbers.ts
+++ b/src/badge/event/safety-in-numbers.ts
@@ -9,9 +9,9 @@ export const SafetyInNumbers: IBadgeData = {
     ],
     alignment: ALIGNMENT_ANY,
     badgeText: [
-        {value: "You've taken down 33 Zombie Minions, showing you have Glimpsed the Abyss."},
+        {value: "You've taken out 33 Zombie Lieutenants, proving that there is Safety in Numbers."},
     ],
-    acquisition: "Defeat 33 Zombie minions during Zombie Apocalypses.",
+    acquisition: "Defeat 33 Zombie lieutenants during Zombie Apocalypses.",
     links: [
         {title: "Safety in Numbers Badge", href: "https://paragonwiki.com/wiki/Safety_in_Numbers_Badge"}
     ],


### PR DESCRIPTION
Updated the following badges:
Chameleon > Moved acquisition info to notes section, added map info
Do No Harm > added acquisition info to notes section, added map info
True Nemesis > added acquisition info to notes section, added map info
Guardian of Forever > added detailed acquisition notes with spoiler tag to notes section, added map info
Evil's Resident > updated badge text and notes to reflect bosses instead of minions
Safety in Numbers > updated badge text and notes to reflect lieutenants instead of minions

Detailed info below (I had to go back and edit a couple of them a second time to include everything I wanted to include)

* Update chameleon.ts

moved details from acquisition to notes

* Update do-no-harm.ts

added acquisition info to the notes section

* Update true-nemesis.ts

added acquisition info to the notes section

* Update guardian-of-forever.ts

added lengthy description with spoiler warning

* Update chameleon.ts

added map info

* Update do-no-harm.ts

added map info

* Update true-nemesis.ts

Added map info

* Update evils-resident.ts

updated badge text and notes

* Update safety-in-numbers.ts

updated badge text and notes