### PR TITLE
Update patroller.ts

### DIFF
--- a/src/badge/day-job/patroller.ts
+++ b/src/badge/day-job/patroller.ts
@@ -4,9 +4,11 @@ export const Patroller: IBadgeData = {
     type: BadgeType.DAY_JOB,
     key: "patroller",
     setTitleId: 1036,
+    setTitleIdPraetorian: 1757,
     names: [
         {type: Alternate.H, value: "Patroller"},
-        {type: Alternate.V, value: "Criminal"}
+        {type: Alternate.V, value: "Criminal"},
+        {type: Alternate.P, value: "Patroller"}
     ],
     alignment: ALIGNMENT_ANY,
     badgeText: [{
@@ -15,6 +17,9 @@ export const Patroller: IBadgeData = {
     }, {
         type: Alternate.V,
         value: "You spent your free time causing havoc in the Rogue Isles and bring terror to its citizens earning the Criminal Day Job."
+    }, {
+        type: Alternate.P,
+        value: "You have spent your free time on the streets, Praetorian or otherwise, earning the Patroller Day Job."
     }],
     acquisition: "Log out anywhere for 100 hours.",
     effect: "Day Job: Patrol XP",

--- a/src/badge/history/alumnus.ts
+++ b/src/badge/history/alumnus.ts
@@ -37,7 +37,7 @@ export const Alumnus: IBadgeData = {
             plaqueType: PlaqueType.MONUMENT,
             location: [541.0, 0.0, -1095.0],
             inscription: `These ruins are all that remains of the original village of Salamanca, established in 1641. Since their arrival, the Cabal have taken over the ruins and made them their home. It has been theorized that they feel most at home among these poor ashes.`,
-            notes: `This plaque is [map:${Croatoa.key}], 167 yards northeast of the Sunset Ridge neighborhood marker.`,
+            notes: `This plaque is in [map:${Croatoa.key}], 167 yards northeast of the Sunset Ridge neighborhood marker.`,
             vidiotMapKey: "1"
         },
         {

--- a/src/badge/history/authority.ts
+++ b/src/badge/history/authority.ts
@@ -49,7 +49,7 @@ export const Authority: IBadgeData = {
             plaqueType: PlaqueType.MONUMENT,
             location: [-1035.0, 36.0, -2441.0],
             inscription: `In 1953, the Freedom Phalanx prevented a ship bearing copious amounts of explosives from docking at this harbor. When the captain was interrogated, it became clear that he was on a mission of sabotage. Public sentiment for the Freedom Phalanx swelled, and Mayor Kyle Legretsky proposed that the Citizens Crime Fighting Act be expanded. He proposed that groups such as the Freedom Phalanx be officially sanctioned fighting forces.`,
-            notes: `This plaque is [map:${IndependencePort.key}], along the road west of Icon, 188 yards due west of the Tailor shop.`,
+            notes: `This plaque is in [map:${IndependencePort.key}], along the road west of Icon, 188 yards due west of the Tailor shop.`,
             vidiotMapKey: "2"
         },
         {

--- a/src/badge/history/digger.ts
+++ b/src/badge/history/digger.ts
@@ -47,7 +47,7 @@ export const Digger: IBadgeData = {
             plaqueType: PlaqueType.MONUMENT,
             location: [-2250.0, 5.0, -2365.0],
             inscription: `This building once housed the lab of Dr. Calvin Stewart, who pioneered Eastgate Bay's Seaview project. Since the Hollowing, Dr. Stewart has been forced to abandon the lab, and communication with the Seaview project has been erratic. Very little is known by the public about the scientists' activities in Eastgate Bay.`,
-            notes: `This plaque is [map:${TheHollows.key}], 740 yards southeast of the Four Seasons neighborhood marker.`,
+            notes: `This plaque is in [map:${TheHollows.key}], 740 yards southeast of the Four Seasons neighborhood marker.`,
             vidiotMapKey: "2"
         },
         {

--- a/src/badge/history/disciple.ts
+++ b/src/badge/history/disciple.ts
@@ -39,7 +39,7 @@ export const Disciple: IBadgeData = {
             plaqueType: PlaqueType.MONUMENT,
             location: [734.0, -121.0, -3747.0],
             inscription: `On this site in March of 1999, the hero Luminary gave a demonstration of his powers. Though public sentiment was against the fledgling company Hero Corps, Luminary was convinced he could turn that sentiment around. When he brought forth an aura of healing light, each person on the street felt touched. Still, some were unmoved. Eliza McCaffrey, one of the spectators remarked, 'Sure, his powers are amazing. That makes me all the more nervous that they're for sale!'`,
-            notes: `This plaque is [map:${SkywayCity.key}], 221 yds WNW of the marker for The Gruff.`,
+            notes: `This plaque is in [map:${SkywayCity.key}], 221 yds WNW of the marker for The Gruff.`,
             vidiotMapKey: "1"
         },
         {

--- a/src/badge/history/historian.ts
+++ b/src/badge/history/historian.ts
@@ -29,7 +29,7 @@ export const Historian: IBadgeData = {
             plaqueType: PlaqueType.WALL_PLAQUE,
             location: [-1528.0, 168.0, 7554.0],
             inscription: `After the devastating 1999 terrorist attack on the Midnight Squad, Rebecca Foss spoke here in favor of the creation of a United Nations Special Council on Super Human Activities. She said, 'Paragon City has suffered a great loss. Someone must step up to take the reins. Hero Corps puts its faith firmly in the proposed U.N. council, and pledges to support all its actions.'`,
-            notes: `This plaque is [map:${TalosIsland.key}], 226 yards East of the Paragon City Monorail marker.`,
+            notes: `This plaque is in [map:${TalosIsland.key}], 226 yards East of the Paragon City Monorail marker.`,
             vidiotMapKey: "4"
         },
         {

--- a/src/badge/history/just-said-no-to-superadine.ts
+++ b/src/badge/history/just-said-no-to-superadine.ts
@@ -39,7 +39,7 @@ export const JustSaidNoToSuperadine: IBadgeData = {
             plaqueType: PlaqueType.WALL_PLAQUE,
             location: [-2178.0, 8.0, 751.0],
             inscription: `This was the site of the first Superadine drug bust. Michael White, otherwise known as the Back Alley Brawler, was patrolling the area when he discovered a pair of thugs haggling over a strange green liquid. He arrested the villains, confiscated the drug, and brought it to the Freedom Phalanx for analysis. The Phalanx's top researcher, Dr. Brian Webb, confirmed the Brawler's worst fears: a new drug had been discovered, and its potency was unprecedented.`,
-            notes: `This plaque is [map:${SteelCanyon.key}] and is wall mounted facing north on the side of a building. It is just east of the Magic Store, 129 yards.`,
+            notes: `This plaque is in [map:${SteelCanyon.key}] and is wall mounted facing north on the side of a building. It is just east of the Magic Store, 129 yards.`,
             vidiotMapKey: "3"
         },
         {

--- a/src/badge/history/park-stroller.ts
+++ b/src/badge/history/park-stroller.ts
@@ -36,7 +36,7 @@ export const ParkStroller: IBadgeData = {
             plaqueType: PlaqueType.WALL_PLAQUE,
             location: [-2368.0, -7.0, -479.0],
             inscription: `To Justin Sinclair the Ziggurat is a thing by which the citizens of Brickstown should feel empowered. It is not a symbol of fear, but one of hope. Sentinel Park admirably looks upon this grand monument knowing that it's not only what keeps Brickstown safe from villainy, but the entirety of Paragon City. Sentinel Park was proudly built with these values in mind.`,
-            notes: `This plaque is [map:${Brickstown.key}], 316 yards east of the Prison Power Station neighborhood marker.`,
+            notes: `This plaque is in [map:${Brickstown.key}], 316 yards east of the Prison Power Station neighborhood marker.`,
             vidiotMapKey: "4"
         },
         {

--- a/src/badge/history/researcher.ts
+++ b/src/badge/history/researcher.ts
@@ -39,7 +39,7 @@ export const Researcher: IBadgeData = {
             plaqueType: PlaqueType.MONUMENT,
             location: [-1147.0, 228.0, 5688.0],
             inscription: `Mayor 'Spanky' Rabinowitz was born on this very street, in 1878 to Aaron and Maria Rabinowitz. Those who knew the mayor well say that he often returned to this area when troubled, to walk the streets he grew up on and contemplate the city's future.`,
-            notes: `This plaque is [map:${TalosIsland.key}], 118 yds due east of the New Corinth marker.`,
+            notes: `This plaque is in [map:${TalosIsland.key}], 118 yds due east of the New Corinth marker.`,
             vidiotMapKey: "3"
         },
         {

--- a/src/badge/history/savant.ts
+++ b/src/badge/history/savant.ts
@@ -38,7 +38,7 @@ export const Savant: IBadgeData = {
             plaqueType: PlaqueType.MONUMENT,
             location: [7227.0, 37.0, -554.0],
             inscription: `This plaque commemorates the last meeting of Statesman and Hero 1. They were the heroes slated to lead the Alpha and Omega Teams, and they knew they would probably not meet again. 'We had only a minute to say goodbye,' Statesman said later. 'So we didn't say anything.' Although Statesman survived Alpha Team's strike on the entrenched Rikti troops, Hero 1 and Omega Team never returned from the Rikti dimension.`,
-            notes: `This plaque is [map:${CreysFolly.key}], 148 yds NNE of Carnival Town.`,
+            notes: `This plaque is in [map:${CreysFolly.key}], 148 yds NNE of Carnival Town.`,
             vidiotMapKey: "1"
         },
         {

--- a/src/badge/history/scholar.ts
+++ b/src/badge/history/scholar.ts
@@ -39,7 +39,7 @@ export const Scholar: IBadgeData = {
             plaqueType: PlaqueType.WALL_PLAQUE,
             location: [-1468.0, 24.0, -2346.0],
             inscription: `This was the site of one of the Regulators' first major victories in their War on Drugs. Led by the Back Alley Brawler, the Regulators surprised a group of thugs who were dealing in heavy narcotics. One of the villains, Harry Frost, later said, 'They may have got the best of me. But mark my words, my Family will rule this town.'`,
-            notes: `This plaque is [map:${SkywayCity.key}] at a rest stop just west of the Talos Island gate. It is on the wall, facing north, hidden in the shadows next to the restrooms. It is 158 yards west-southwest of the Talos Island gate.`,
+            notes: `This plaque is in [map:${SkywayCity.key}] at a rest stop just west of the Talos Island gate. It is on the wall, facing north, hidden in the shadows next to the restrooms. It is 158 yards west-southwest of the Talos Island gate.`,
             vidiotMapKey: "3"
         },
         {

--- a/src/badge/history/scholastic.ts
+++ b/src/badge/history/scholastic.ts
@@ -37,7 +37,7 @@ export const Scholastic: IBadgeData = {
             plaqueType: PlaqueType.WALL_PLAQUE,
             location: [-229.0, 8.0, -370.0],
             inscription: `This building was once the lab of Dr. Brian Webb, the brilliant scientist who broke the dimensional barrier and opened up whole new worlds to science. His notes reveal that his findings were linked to previous scientists' research on the effects of the drug Superadine. Much has been made of this discovery, but the link between the drug and the dimensional barrier remains a mystery.`,
-            notes: `This plaque is [map:${Brickstown.key}]. It is on the east side of a building 430 yards due south of the Paragon City Monorail station and 67 yards east-northeast of Detective Fish.`,
+            notes: `This plaque is in [map:${Brickstown.key}]. It is on the east side of a building 430 yards due south of the Paragon City Monorail station and 67 yards east-northeast of Detective Fish.`,
             vidiotMapKey: "1"
         },
         {

--- a/src/badge/history/student.ts
+++ b/src/badge/history/student.ts
@@ -38,7 +38,7 @@ export const Student: IBadgeData = {
             plaqueType: PlaqueType.MONUMENT,
             location: [1200.0, 4.0, 384.0],
             inscription: `On January 6th, 1937, Maiden Justice of the Freedom Phalanx arrested a group of violent thugs at this location. Although Maiden Justice was able to prevent the thugs from torching the building, the perpetrators were released by policed on the grounds that the arrest had not been legally sanctioned. The public outcry was immediate. Politicians put their heads together and the Citizen Crime Fighting Act was born.`,
-            notes: `This plaque is [map:${AtlasPark.key}], 179 yards northeast of the Downside marker.`,
+            notes: `This plaque is in [map:${AtlasPark.key}], 179 yards northeast of the Downside marker.`,
             vidiotMapKey: "3"
         },
         {


### PR DESCRIPTION
This is a strange one. It has a Praetorian variant that has the same name as the hero variant. However, according to the wiki, if a character is of Praetorian origin, then regardless of their alignment, they earn the Patroller badge. Therefore I added the Praetorian ID, the Praetorian name variant, and the Praetorian badge text variant.