### PR TITLE
Above the chemist patch 1

### DIFF
--- a/src/badge/achievement/firebase-zulu-security-detail.ts
+++ b/src/badge/achievement/firebase-zulu-security-detail.ts
@@ -21,6 +21,7 @@ export const FirebaseZuluSecurityDetail: IBadgeData = {
         {title: "Firebase Zulu Deserter Badge", href: "https://paragonwiki.com/wiki/Firebase_Zulu_Deserter_Badge"}
     ],
     icons: [
-        {value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time.png"}
+        {type: Alternate.H, value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time-h.png"},
+        {type: Alternate.V, value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time-v.png"}
     ],
 };

--- a/src/badge/achievement/irradiated.ts
+++ b/src/badge/achievement/irradiated.ts
@@ -1,4 +1,4 @@
-import {ALIGNMENT_ANY, BadgeType, IBadgeData} from "coh-content-db";
+import {ALIGNMENT_ANY, Alternate, BadgeType, IBadgeData} from "coh-content-db";
 
 export const Irradiated: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
@@ -9,13 +9,14 @@ export const Irradiated: IBadgeData = {
     ],
     alignment: ALIGNMENT_ANY,
     badgeText: [
-        {value: "You've basked for more than five hours in the weird radiation of Bloody Bay."}
+        {value: "You've basked for more than one hour in the weird radiation of Bloody Bay."}
     ],
     acquisition: "Spend 1 hour in Bloody Bay",
     links: [
         {title: "Irradiated Badge", href: "https://paragonwiki.com/wiki/Irradiated_Badge"}
     ],
     icons: [
-        {value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time.png"}
+        {type: Alternate.H, value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time-h.png"},
+        {type: Alternate.V, value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time-v.png"}
     ],
 };

--- a/src/badge/achievement/sirens-song.ts
+++ b/src/badge/achievement/sirens-song.ts
@@ -10,7 +10,7 @@ export const SirensSong: IBadgeData = {
     ],
     alignment: ALIGNMENT_ANY,
     badgeText: [
-        {value: "Siren's Call must call to you. You've spent over 5 hours here."}
+        {value: "Siren's Call must call to you. You've spent over one hour there."}
     ],
     acquisition: "Spend 1 hours in Siren's Call",
     links: [
@@ -18,6 +18,7 @@ export const SirensSong: IBadgeData = {
         {title: "Raider Badge", href: "https://paragonwiki.com/wiki/Raider_Badge"}
     ],
     icons: [
-        {value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time.png"}
+        {type: Alternate.H, value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time-h.png"},
+        {type: Alternate.V, value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time-v.png"}
     ],
 };

--- a/src/badge/achievement/time-traveler.ts
+++ b/src/badge/achievement/time-traveler.ts
@@ -1,4 +1,4 @@
-import {ALIGNMENT_ANY, BadgeType, IBadgeData} from "coh-content-db";
+import {ALIGNMENT_ANY, Alternate, BadgeType, IBadgeData} from "coh-content-db";
 
 export const TimeTraveler: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
@@ -9,14 +9,15 @@ export const TimeTraveler: IBadgeData = {
     ],
     alignment: ALIGNMENT_ANY,
     badgeText: [
-        {value: "It seems you have mastered the recursive time flux of Lord Recluse's victory. You've spent 5 " +
-        "hours here, though it seems like much longer."}
+        {value: "It seems you have mastered the recursive time flux of Lord Recluse's victory. You've spent one " +
+        "hour here, though it seems like much longer."}
     ],
     acquisition: "Spend 1 hour in Recluse's Victory",
     links: [
         {title: "Time Traveler Badge", href: "https://paragonwiki.com/wiki/Time_Traveler_Badge"}
     ],
     icons: [
-        {value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time.png"}
+        {type: Alternate.H, value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time-h.png"},
+        {type: Alternate.V, value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time-v.png"}
     ],
 };

--- a/src/badge/achievement/troll-task-force-member.ts
+++ b/src/badge/achievement/troll-task-force-member.ts
@@ -1,4 +1,4 @@
-import {ALIGNMENT_HERO, BadgeType, IBadgeData} from "coh-content-db";
+import {ALIGNMENT_HERO, Alternate, BadgeType, IBadgeData} from "coh-content-db";
 
 export const TrollTaskForceMember: IBadgeData = {
     type: BadgeType.ACHIEVEMENT,
@@ -17,6 +17,7 @@ export const TrollTaskForceMember: IBadgeData = {
         {title: "Troll Task Force Member Badge", href: "https://paragonwiki.com/wiki/Troll_Task_Force_Member_Badge"}
     ],
     icons: [
-        {value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time.png"}
+        {type: Alternate.H, value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time-h.png"},
+        {type: Alternate.V, value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time-v.png"}
     ],
 };

--- a/src/badge/achievement/web-master.ts
+++ b/src/badge/achievement/web-master.ts
@@ -9,9 +9,9 @@ export const WebMaster: IBadgeData = {
     ],
     alignment: ALIGNMENT_ANY,
     badgeText: [
-        {type: Alternate.H, value: "You are a well-known threat in the chaotic district of Warburg, having spent well over 5 hours " +
+        {type: Alternate.H, value: "You are a well-known threat in the chaotic district of Warburg, having spent well over one hour " +
         "fighting Arachnos."},
-        {type: Alternate.V, value: "You are a well-known threat in the chaotic district of Warburg, having spent well over 5 hours " +
+        {type: Alternate.V, value: "You are a well-known threat in the chaotic district of Warburg, having spent well over one hour " +
         "fighting Longbow."}
     ],
     acquisition: "Spend 1 hour in Warburg",
@@ -19,6 +19,7 @@ export const WebMaster: IBadgeData = {
         {title: "Web Master Badge", href: "https://paragonwiki.com/wiki/Web_Master_Badge"}
     ],
     icons: [
-        {value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time.png"}
+        {type: Alternate.H, value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time-h.png"},
+        {type: Alternate.V, value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/achievement/time-v.png"}
     ],
 };


### PR DESCRIPTION
Updated six files that had different hero/villain icons, and fixed badge text for four of those that are PvP zone badges where requirements to earn badge dropped from 5 hours to 1 hour spent in zone