### PR TITLE
Update 1

### DIFF
--- a/src/badge/exploration/on-the-shoulders-of-giants.ts
+++ b/src/badge/exploration/on-the-shoulders-of-giants.ts
@@ -4,7 +4,17 @@ import {KallistiWharf} from "../../map/kallisti-wharf";
 export const OnTheShouldersOfGiants: IBadgeData = {
     type: BadgeType.EXPLORATION,
     key: "on-the-shoulders-of-giants",
+    setTitleId: 2449,
     names: [{value: "On the Shoulders of Giants"}],
     alignment: ALIGNMENT_ANY,
-    mapKey: KallistiWharf.key
+    mapKey: KallistiWharf.key,
+    location: [4286.0, 148.0, 2720.0],
+    badgeText: [{
+        value: `This statue was erected to pay tribute to Marcus Cole, publicly known as Statesman. Ms. Liberty and Longbow have refused to confirm or deny the persistent rumor that the statue was commissioned by Stefan Richter himself.`
+    }],
+    notes: `Located on the left shoulder of the statue of Statesman in the center of [map:kallisti-wharf], within 100 ft of the One Statesman Plaza neighborhood marker.`,
+    links: [
+        {title: "On the Shoulders of Giants", href: "https://hcwiki.cityofheroes.dev/wiki/On_the_Shoulders_of_Giants_Badge"}
+    ],
+    icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/exploration/hero.png"}]
 };

--- a/src/badge/exploration/orions-belt.ts
+++ b/src/badge/exploration/orions-belt.ts
@@ -8,13 +8,13 @@ export const OrionsBelt: IBadgeData = {
     names: [{value: "Orion's Belt"}],
     alignment: ALIGNMENT_HERO,
     mapKey: EchoGalaxyCity.key,
-    location: [-1699.0, 4.0, 2209.0],
+    location: [-1699.0, 4.0, -2209.0],
     badgeText: [{
         value: "This statue commemorates the hero Orion, whom Orion Beltway was renamed after." +
             " During the first Rikti War, Orion fought valiantly against the Rikti, saving the people of this small district." +
             " He was remembered, in particular, as the hero with no real powers beyond his knowledge of martial arts."
     }],
-    notes: "The Orion's Belt Badge is located in the Orion Beltway neighborhood of Echo: Galaxy City. It is at the base of the statue 269 yards ESE of the neighborhood marker.",
+    notes: "Located in the Orion Beltway neighborhood of [map:echo-galaxy-city], at the base of the statue 269 yards ESE of the neighborhood marker.",
     links: [
         {title: "Orion's Belt Badge", href: "https://paragonwiki.com/wiki/Orion%27s_Belt_Badge"}
     ],

--- a/src/badge/history/disciple.ts
+++ b/src/badge/history/disciple.ts
@@ -2,7 +2,7 @@ import {ALIGNMENT_HERO, BadgePartialType, BadgeType, IBadgeData, PlaqueType} fro
 import {SteelCanyon} from "../../map/steel-canyon";
 import {SkywayCity} from "../../map/skyway-city";
 import {Boomtown} from "../../map/boomtown";
-import {Faultline} from "../../map/faultline";
+import {EchoFaultline} from "../../map/echo-faultline";
 
 export const Disciple: IBadgeData = {
     type: BadgeType.HISTORY,
@@ -75,21 +75,21 @@ export const Disciple: IBadgeData = {
         {
             key: "disc-5",
             type: BadgePartialType.PLAQUE,
-            mapKey: Faultline.key,
+            mapKey: EchoFaultline.key,
             plaqueType: PlaqueType.MONUMENT,
-            location: [-245.0, -44.0, -423.0],
+            location: [-75.0, -613.0, -14.0],
             inscription: `In May of 1999, following the destruction of Hero Corps' original Paragon City headquarters, Countess Crey held a conference at this site to announce her sponsorship of the ill-fated company. She joined hands with Rebecca Foss, Hero Corps' founder, and said, 'A new world of heroes is upon us. Crey Technologies will not be left behind.'`,
-            notes: `This plaque is in [map:${Faultline.key}], 180 yds north of the Aftershock marker.`,
+            notes: `This plaque is in [map:${EchoFaultline.key}], 325 yds southwest of the Aftershock marker.`,
             vidiotMapKey: "1"
         },
         {
             key: "disc-6",
             type: BadgePartialType.PLAQUE,
-            mapKey: Faultline.key,
+            mapKey: EchoFaultline.key,
             plaqueType: PlaqueType.MONUMENT,
-            location: [631.0, -103.0, 21.0],
+            location: [135.0, -868.0, 1011.0],
             inscription: `This plaque marks the site of the original Hero Corps headquarters, which was destroyed by a gang of mysterious soldiers clad in power armor. Although Hero Corps' employees made it out alive, Hero Corps was devastated by the loss. Its founder, Rebecca Foss, spoke tearfully the next morning on the radio program 'Wake up Paragons.' 'Who could hate us so much?' she asked, 'We only want to help!'`,
-            notes: `This plaque is in [map:${Faultline.key}], 227 yds due west of the Aftershock marker.`,
+            notes: `This plaque is in [map:${EchoFaultline.key}], 227 yds north-northwest of the Reservoir marker.`,
             vidiotMapKey: "2"
         }
     ]

--- a/src/badge/history/just-said-no-to-superadine.ts
+++ b/src/badge/history/just-said-no-to-superadine.ts
@@ -2,7 +2,7 @@ import {ALIGNMENT_HERO, BadgePartialType, BadgeType, IBadgeData, PlaqueType} fro
 import {SteelCanyon} from "../../map/steel-canyon";
 import {SkywayCity} from "../../map/skyway-city";
 import {Boomtown} from "../../map/boomtown";
-import {Faultline} from "../../map/faultline";
+import {EchoFaultline} from "../../map/echo-faultline";
 
 export const JustSaidNoToSuperadine: IBadgeData = {
     type: BadgeType.HISTORY,
@@ -65,11 +65,11 @@ export const JustSaidNoToSuperadine: IBadgeData = {
         {
             key: "just-4",
             type: BadgePartialType.PLAQUE,
-            mapKey: Faultline.key,
-            plaqueType: PlaqueType.WALL_PLAQUE,
-            location: [-920.0, 7.0, -640.0],
+            mapKey: EchoFaultline.key,
+            plaqueType: PlaqueType.MONUMENT,
+            location: [-904.0, 17.0, -1983.0],
             inscription: `In late 1982, the Back Alley Brawler and his Regulators were trying to mop up the last traces of Superadine on the city streets. A tip led them to this building, a front company for the Family. During the raid, Harry Frost, the Family's leader, was accidentally killed, leaving his young son Sebastian to oversee his business. Since then, Superadine sales have inexplicably increased, despite the best efforts of the Brawler and his comrades.`,
-            notes: `This plaque is in [map:${Faultline.key}]. It is wall mounted facing east just north of Yin's Market, 78 yards Southeast of Freight Lift A.`,
+            notes: `This plaque is in [map:${EchoFaultline.key}], 325 yards due east of the Downfall neighborhood marker.`,
             vidiotMapKey: "3"
         }
     ]

--- a/src/badge/history/scholar.ts
+++ b/src/badge/history/scholar.ts
@@ -2,7 +2,7 @@ import {ALIGNMENT_HERO, BadgePartialType, BadgeType, IBadgeData, PlaqueType} fro
 import {SteelCanyon} from "../../map/steel-canyon";
 import {SkywayCity} from "../../map/skyway-city";
 import {Boomtown} from "../../map/boomtown";
-import {Faultline} from "../../map/faultline";
+import {EchoFaultline} from "../../map/echo-faultline";
 
 export const Scholar: IBadgeData = {
     type: BadgeType.HISTORY,
@@ -65,11 +65,11 @@ export const Scholar: IBadgeData = {
         {
             key: "schr-4",
             type: BadgePartialType.PLAQUE,
-            mapKey: Faultline.key,
+            mapKey: EchoFaultline.key,
             plaqueType: PlaqueType.MONUMENT,
-            location: [866.0, 31.0, -1673.0],
+            location: [-21.0, -577.0, 359.0],
             inscription: `This plaque commemorates the death of Mina Horne, known to her comrades as the Illustrated Woman. She was killed when the Frost drug cartel, otherwise known as the Family, ambushed the Regulators as revenge for the brief imprisonment of Harry Frost. At her funeral, a shaken Back Alley Brawler said, 'Mina was a person who believed in the human spirit. We can best honor her by living the life she fought for.'`,
-            notes: `This plaque is in [map:${Faultline.key}], 436 yards West of the Overbrook Medical Center.`,
+            notes: `This plaque is in [map:${EchoFaultline.key}], 425 yards south-southeast of the Aftershock neighborhood marker.`,
             vidiotMapKey: "4"
         }
     ]


### PR DESCRIPTION
Added missing info for Kallisti explore badge (On the Shoulders of Giants)
Updated coordinates for explore badge in Echo: GC
4 history plaques that are in Echo: Faultline were listed as being in Faultline. Correct that along with updating coordinates, notes, etc as necessary