### PR TITLE
Update 12-2020

### DIFF
--- a/src/badge/history/headjuiced.ts
+++ b/src/badge/history/headjuiced.ts
@@ -1,4 +1,4 @@
-import {ALIGNMENT_PRAETORIAN, BadgePartialType, BadgeType, IBadgeData, PlaqueType} from "coh-content-db";
+import {ALIGNMENT_ANY, BadgePartialType, BadgeType, IBadgeData, PlaqueType} from "coh-content-db";
 import {NovaPraetoria} from "../../map/nova-praetoria";
 import {ImperialCity} from "../../map/imperial-city";
 import {Neutropolis} from "../../map/neutropolis";
@@ -13,7 +13,7 @@ export const Headjuiced: IBadgeData = {
     names: [
         {value: "Headjuiced"}
     ],
-    alignment: ALIGNMENT_PRAETORIAN,
+    alignment: ALIGNMENT_ANY,
     badgeText: [
         {value: `You followed all the fruity crumbs and peeped the 20 lessons brought to you by the letter 'Resistance.' Whether or not you chomp-a-chomp on this tasty knowing is up to you, but now you know it's time for the other half of the battle.`}
     ],

--- a/src/badge/history/starstruck.ts
+++ b/src/badge/history/starstruck.ts
@@ -1,4 +1,4 @@
-import {ALIGNMENT_PRAETORIAN, BadgePartialType, BadgeType, IBadgeData, PlaqueType} from "coh-content-db";
+import {ALIGNMENT_ANY, BadgePartialType, BadgeType, IBadgeData, PlaqueType} from "coh-content-db";
 import {NovaPraetoria} from "../../map/nova-praetoria";
 
 export const Starstruck: IBadgeData = {
@@ -8,7 +8,7 @@ export const Starstruck: IBadgeData = {
     names: [
         {value: "Starstruck"}
     ],
-    alignment: ALIGNMENT_PRAETORIAN,
+    alignment: ALIGNMENT_ANY,
     badgeText: [
         {value: `Seeing the statues of the rulers of Praetoria is awe-inspiring, truly a must for any loyal citizen.`}
     ],

--- a/src/badge/history/swashbuckler.ts
+++ b/src/badge/history/swashbuckler.ts
@@ -47,7 +47,7 @@ export const Swashbuckler: IBadgeData = {
             type: BadgePartialType.PLAQUE,
             mapKey: SirensCall.key,
             plaqueType: PlaqueType.MONUMENT,
-            location: [-942.0, -157.0, 200.0],
+            location: [-200.0, -157.0, -942.0],
             inscription: `One of the cruelest pirates to roam these seas was Jean L'Olonnais. L'Olonnais hated the Spanish and murdered and tortured them every chance he got, even forcing one prisoner to eat another's heart. The pirate even commanded massive field armies and raided entire towns in the Caribbean and Rogue Isles. Eventually, the black-hearted fiend was captured by cannibals, and met a fitting end.`,
             notes: `Go to the eastern wall of the zone, in the middle of the northern section, right in the space between the Randall's Ruins and the Fossburg neighborhood boundaries. Look just west of the wall for the tallest, brown, thin smokestack that points the straightest upwards. The plaque is located right at the bottom of that smokestack, 255 yards south-south-east of the Fossburg marker.`,
             vidiotMapKey: "1"


### PR DESCRIPTION
Updated Headjuiced and Starstruck history badges to Any alignment to reflect fact that they can be earned by any alignment. Updated Swashbuckler history badge to correct coordinates of plaque in Siren's Call after that zone was rotated in i27. 