### PR TITLE
Correction and bug note for Ink Man

### DIFF
--- a/src/badge/gladiator/ink-man.ts
+++ b/src/badge/gladiator/ink-man.ts
@@ -11,7 +11,7 @@ export const InkMan: IBadgeData = {
     badgeText: [
         {value: "You have allowed these Tsoo to fight for you."}
     ],
-    acquisition: "Defeat 125 Blue Ink Men (Tsoo)",
+    acquisition: "Defeat 100 Blue Ink Men (Tsoo) other than level 30-40 Dragon Blue Ink Men",
     links: [
         {title: "Ink Man Badge", href: "https://paragonwiki.com/wiki/Ink_Man_Badge"}
     ],


### PR DESCRIPTION
100 defeats instead of 125. Level 30-40 Eagle, Serpent, and Tiger Blue Ink Men count, and all level 50-54 Blue Ink Men count. Level 30-40 Dragon Blue Ink Men don't count, due to a likely oversight in badges.bin.