### PR TITLE
Passport list order

### DIFF
--- a/src/badge/accolade/_accolade-badges.ts
+++ b/src/badge/accolade/_accolade-badges.ts
@@ -136,6 +136,7 @@ import {ZigWarden} from "./zig-warden";
 import {Passport} from "./passport";
 
 export const AccoladeBadges: IBadgeData[] = [
+    Passport,
     ThornRobber,
     ThornThief,
     ThornUsurper,
@@ -270,5 +271,4 @@ export const AccoladeBadges: IBadgeData[] = [
     GeasOfTheKindOnes,
     Chronomaster,
     FlamesOfPrometheus,
-    Passport,
 ];


### PR DESCRIPTION
Issue 27 moved Passport from the bottom of the accolade list to the top.