### PR TITLE
additional changes for Issue 27 p2

### DIFF
--- a/src/badge/accomplishment/chameleon.ts
+++ b/src/badge/accomplishment/chameleon.ts
@@ -11,7 +11,7 @@ export const Chameleon: IBadgeData = {
     ],
     alignment: ALIGNMENT_HERO,
     badgeText: [{value: `You infiltrated the Freakshow and recovered the stolen Chameleon Suit.`}],
-    icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/accomp_stature_05.png"}],
+    icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/chameleon.png"}],
     acquisition: `Complete the task set 'The Chameleon Suit'`,
     notes: `The task set 'The Chameleon Suit' begins with the 'Infiltrate the Freakshow and recover the stolen Chameleon Suit' mission from any one of the level 20-24 contacts Andrew Fiore or Lt. Col. Hugh McDougal in [map:${TalosIsland.key}], or Jake Kim or Wilma Peterson in [map:${IndependencePort.key}]. It is also available via Ouroboros, level 20-24, mission 0.12 'The Chameleon Suit'.`,
     links: [

--- a/src/badge/accomplishment/do-no-harm.ts
+++ b/src/badge/accomplishment/do-no-harm.ts
@@ -10,7 +10,7 @@ export const DoNoHarm: IBadgeData = {
     ],
     alignment: ALIGNMENT_HERO,
     badgeText: [{value: `You have delivered medical supplies to the Rikti.`}],
-    icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/accomp_stature_11.png"}],
+    icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/do_no_harm.png"}],
     acquisition: `Complete the task set 'Hippocratic Oath'.`,
     notes: `The task set 'Hippocratic Oath' begins with the 'Rescue the doctors from the Rikti' mission from level 35-39 contact Steven Sheridan in [map:${Brickstown.key}]. It is also available via Ouroboros, level 35-39, mission 0.35 'Hippocratic Oath'.`,
     links: [

--- a/src/badge/accomplishment/frontline.ts
+++ b/src/badge/accomplishment/frontline.ts
@@ -8,7 +8,7 @@ export const Frontline: IBadgeData = {
         {value: "Frontline"}
     ],
     alignment: ALIGNMENT_HERO,
-    icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/accomp_stature_11.png"}],
+    icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/frontline.png"}],
     badgeText: [
         {value: "You stopped a battle between the Circle of Thorns and the Oranbegans from another dimension."}
     ],

--- a/src/badge/accomplishment/meteorologist.ts
+++ b/src/badge/accomplishment/meteorologist.ts
@@ -8,7 +8,7 @@ export const Meteorologist: IBadgeData = {
         {value: "Meteorologist"}
     ],
     alignment: ALIGNMENT_HERO,
-    icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/accomp_stature_13.png"}],
+    icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/meteorologist.png"}],
     badgeText: [
         {value: "You have crushed Nemesis' weather controlling equipment."}
     ],

--- a/src/badge/accomplishment/pwnz.ts
+++ b/src/badge/accomplishment/pwnz.ts
@@ -8,7 +8,7 @@ export const Pwnz: IBadgeData = {
         {value: "Pwnz"}
     ],
     alignment: ALIGNMENT_HERO,
-    icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/accomp_stature_05.png"}],
+    icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/pwnz.png"}],
     badgeText: [
         {value: "You have arrested one of the higher ranking members of the Freakshow."}
     ],

--- a/src/badge/accomplishment/true-nemesis.ts
+++ b/src/badge/accomplishment/true-nemesis.ts
@@ -10,7 +10,7 @@ export const TrueNemesis: IBadgeData = {
     ],
     alignment: ALIGNMENT_HERO,
     badgeText: [{value: `You have stopped Nemesis Rex's incursion into Primal Earth.`}],
-    icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/accomp_stature_13.png"}],
+    icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/true_nemesis.png"}],
     acquisition: `Complete the task set 'Nemesis Rex'.`,
     notes: `The task set 'Nemesis Rex' begins with the 'Stop the battle between Nemesis Army factions and make sure no innocents get hurt' mission from level 40-44 contact Maxwell Christopher in [map:${FoundersFalls.key}]. It is also available via Ouroboros, level 40-49, mission 1.07 'Nemesis Rex'.`,
     links: [

--- a/src/badge/exploration/ambitious.ts
+++ b/src/badge/exploration/ambitious.ts
@@ -8,7 +8,7 @@ export const Ambitious: IBadgeData = {
     names: [{value: "Ambitious"}],
     alignment: ALIGNMENT_ANY,
     mapKey: NovaPraetoria.key,
-    location: [-5398.0, 190.0, -255.0],
+    location: [-5420.9, 1088.6, -255.3],
     badgeText: [{
         value: "Even in these strange and uncertain times there are those who still reach for the sky."
     }],

--- a/src/badge/exploration/asunder.ts
+++ b/src/badge/exploration/asunder.ts
@@ -8,7 +8,7 @@ export const Asunder: IBadgeData = {
     names: [{value: "Asunder"}],
     alignment: ALIGNMENT_ANY,
     mapKey: EchoRiktiCrashSite.key,
-    location: [3954.1, 34.0, -3858.8],
+    location: [3969.7, 34.3, -3851.5],
     badgeText: [{value: "This fort is the prime location to be for surveilling Rikti activity. Unfortunately, it's also the furthest from the Vanguard base and, thus, a big target for the Rikti."}],
     notes: "**Moved from [map:rikti-war-zone] in Issue 25.**\n" +
         "\n" +

--- a/src/badge/exploration/bright-star.ts
+++ b/src/badge/exploration/bright-star.ts
@@ -8,7 +8,7 @@ export const BrightStar: IBadgeData = {
     names: [{value: "Bright Star"}],
     alignment: ALIGNMENT_HERO,
     mapKey: SteelCanyon.key,
-    location: [-2987.0, -36.0, 1820.0],
+    location: [-3001.3, -26.2, 1830.0],
     badgeText: [{
         value: "The first Luminary used her light-based powers to disrupt the formation of a large portal to the Rikti homeworld on this spot."
     }],

--- a/src/badge/exploration/dug-too-deep.ts
+++ b/src/badge/exploration/dug-too-deep.ts
@@ -9,7 +9,7 @@ export const DugTooDeep: IBadgeData = {
     alignment: ALIGNMENT_HERO,
     badgeText: [{value: `Though magical runes and protection spells were once used to hide Oranbega from the rest of the world, all that ended with the Rikti War. Now, anyone who finds a physical entrance in the dark canyons may reach the sunken city... if they're brave or foolish enough to do so.`}],
     mapKey: EchoFaultline.key,
-    location: [1141.7, -618.3, -16.0],
+    location: [1151.5, -615.4, -28.5],
     notes: "Directly south of the dark canyons marker, down in the cracks.",
     links: [
         {title: "I25 Faultline badge changes", href: "https://forums.homecomingservers.com/topic/931-echo-falutline-badger-hunter-helpline/"}

--- a/src/badge/exploration/forward-thinker.ts
+++ b/src/badge/exploration/forward-thinker.ts
@@ -8,7 +8,7 @@ export const ForwardThinker: IBadgeData = {
     names: [{value: "Forward Thinker"}],
     alignment: ALIGNMENT_HERO,
     mapKey: Brickstown.key,
-    location: [395.0, 32.0, -1344.0],
+    location: [254.0, 31.8, -1343.5],
     badgeText: [{
         value: "The Mashu bridge was built in Brickstown long before construction on the Zig began." +
             " Traffic was heavy in Brickstown, causing a need for this bridge to be constructed." +

--- a/src/badge/exploration/freedom.ts
+++ b/src/badge/exploration/freedom.ts
@@ -11,7 +11,7 @@ export const Freedom: IBadgeData = {
     ],
     alignment: ALIGNMENT_HERO,
     mapKey: AtlasPark.key,
-    location: [128.0, 122.0, -641.0],
+    location: [126.1, 170.6, -652.4],
     badgeText: [{
         value: "This flag was crafted from Statesman's cape and was donated to Paragon City to replace the flag destroyed by the invading Rikti." +
             " It now flies over Paragon City Hall to honor the sacrifice made by Hero 1 and the rest of Omega Team."

--- a/src/badge/exploration/stonekeeper.ts
+++ b/src/badge/exploration/stonekeeper.ts
@@ -8,7 +8,7 @@ export const Stonekeeper: IBadgeData = {
     names: [{value: "Stonekeeper"}],
     alignment: ALIGNMENT_VILLAIN,
     mapKey: StMartial.key,
-    location: [-2560.0, 116.0, 3009.0],
+    location: [-2566.0, 119.8, 3000.5],
     badgeText: [{
         value: `What strange purpose do these glyphs serve?`
     }],

--- a/src/badge/exploration/top-dog.ts
+++ b/src/badge/exploration/top-dog.ts
@@ -8,7 +8,7 @@ export const TopDog: IBadgeData = {
     names: [{value: "Top Dog"}],
     alignment: ALIGNMENT_HERO,
     mapKey: AtlasPark.key,
-    location: [134.0, 314.0, -340.0],
+    location: [131.0, 320.0, -319.5],
     badgeText: [{
         value: "The top of Atlas' statue is the first place many flying heroes will go."
     }],

--- a/src/badge/exploration/vanguard-operative.ts
+++ b/src/badge/exploration/vanguard-operative.ts
@@ -8,7 +8,7 @@ export const VanguardOperative: IBadgeData = {
     names: [{value: "Vanguard Operative"}],
     alignment: ALIGNMENT_ANY,
     mapKey: RiktiWarZone.key,
-    location: [388.0, -1188.0, -2418.0],
+    location: [328.0, -1188.2, -2444.5],
     badgeText: [{value: "You have entered the Vanguard base where all your efforts will now go towards fighting the Rikti. The Vanguard and your natural enemies are now your allies."}],
     notes: "The Vanguard Operative Badge is located in Vanguard Base in the [map:${RiktiWarZone.key}].\n" +
         "\n" +

--- a/src/badge/history/alumnus.ts
+++ b/src/badge/history/alumnus.ts
@@ -25,7 +25,7 @@ export const Alumnus: IBadgeData = {
             type: BadgePartialType.PLAQUE,
             mapKey: AtlasPark.key,
             plaqueType: PlaqueType.WALL_PLAQUE,
-            location: [-640.0, 18.0, 943.0],
+            location: [-640.0, 19.1, 1021.4],
             inscription: `On October 31, 2004, a creature known as Eochai was defeated on this spot. Although the creature and its minions were thought to be vanquished by Paragon City's heroes, it appears they have simply relocated. The northern village of Salamanca is beset by the creatures and is in grave need of heroic assistance.`,
             notes: `This plaque is in [map:${AtlasPark.key}], 326 yards due east of the entrance to the Sewer Network.`,
             vidiotMapKey: "7"

--- a/src/badge/history/digger.ts
+++ b/src/badge/history/digger.ts
@@ -25,7 +25,7 @@ export const Digger: IBadgeData = {
             type: BadgePartialType.PLAQUE,
             mapKey: AtlasPark.key,
             plaqueType: PlaqueType.MONUMENT,
-            location: [1155.0, 47.0, -776.0],
+            location: [1155.3, 46.1, -812.1],
             inscription: `On this site, the Trolls Task Force was formed in response to the devastating event known as the Hollowing. Police Chief James Wilson said 'The police department will not stop until the residents of Eastgate can go home again.'`,
             notes: `This plaque is in [map:${AtlasPark.key}], 7 feet north of the Prometheus Park neighborhood marker, on the overpass overlooking a lake. It is also 112 feet west and slightly north of the Fort Trident marker.`,
             vidiotMapKey: "6"

--- a/src/badge/history/expert.ts
+++ b/src/badge/history/expert.ts
@@ -26,7 +26,7 @@ export const Expert: IBadgeData = {
             type: BadgePartialType.PLAQUE,
             mapKey: AtlasPark.key,
             plaqueType: PlaqueType.WALL_PLAQUE,
-            location: [631.0, 8.0, 961.0],
+            location: [634.0, 6.4, 826.4],
             inscription: `This statue honors Georgia Reynolds, one of the first heroes to publicly challenge the Might for Right Act. Although she fought the conscription of heroes under this act, she later joined the armed forces and performed many services for her country under the code name Nimbus. She is best remembered for her service during the Rikti War, when she and the rest of Alpha Team assaulted the Rikti's entrenched positions, buying Omega Team time to sneak into the Rikti barracks and enter the portal to the Rikti homeworld.`,
             notes: `This plaque is in [map:${AtlasPark.key}], beneath the statue 182 yards west of the Sewer Network entrance or 166 yards east of the Skyway City entrance.`,
             vidiotMapKey: "4"

--- a/src/badge/history/headjuiced.ts
+++ b/src/badge/history/headjuiced.ts
@@ -79,7 +79,7 @@ export const Headjuiced: IBadgeData = {
             type: BadgePartialType.PLAQUE,
             mapKey: ImperialCity.key,
             plaqueType: PlaqueType.WALL_PLAQUE,
-            location: [-2100.0, -36.0, -1655.0],
+            location: [-2109.7, -28.3, -1656.1],
             inscription: `This is the Cage and You're the Guinea Pig - Praetor Berry is the best propeller-head Praetoria has ever seen. And you're the best test subject he's ever seen, too. Welcome to your new life as a technologically assimilated lab mouse, chomper!`,
             notes: `Located 38 yards N of Underground Access C.`,
             vidiotMapKey: "1"

--- a/src/badge/history/intellectual.ts
+++ b/src/badge/history/intellectual.ts
@@ -27,7 +27,7 @@ export const Intellectual: IBadgeData = {
             type: BadgePartialType.PLAQUE,
             mapKey: AtlasPark.key,
             plaqueType: PlaqueType.MONUMENT,
-            location: [2547.0, 5.0, -1182.0],
+            location: [2380.5, 4.1, -1254.0],
             inscription: `The warehouse you see before you was instrumental in the Lost's plan to psychically dominate the city. After the Grimm Fairy apprehended the group's ringleader, Ishmael, she discovered that the Lost had kept many citizens imprisoned here for months in order to practice their mental techniques on live subjects. Horrified, the Grimm Fairy appealed for help to the Freedom Phalanx, and Positron dispatched a Task Force to rescue the imprisoned civilians.`,
             notes: `This plaque is in [map:${AtlasPark.key}], 72 yards north and slightly west of the Argosy Industrial neighborhood marker.`,
             vidiotMapKey: "5"

--- a/src/badge/history/pupil.ts
+++ b/src/badge/history/pupil.ts
@@ -27,7 +27,7 @@ export const Pupil: IBadgeData = {
             type: BadgePartialType.PLAQUE,
             mapKey: AtlasPark.key,
             plaqueType: PlaqueType.MONUMENT,
-            location: [511.0, 5.0, -1151.0],
+            location: [495.2, 4.3, -1132.9],
             inscription: `On this spot the titanic hero Atlas was posthumously awarded a key to the city for his many valiant efforts on behalf of its citizens.`,
             notes: `This plaque is in [map:${AtlasPark.key}], at the northwest corner of Atlas Plaza and just south of the Paragon City Monorail.`,
             vidiotMapKey: "1"

--- a/src/badge/history/scholar.ts
+++ b/src/badge/history/scholar.ts
@@ -57,7 +57,7 @@ export const Scholar: IBadgeData = {
             type: BadgePartialType.PLAQUE,
             mapKey: Boomtown.key,
             plaqueType: PlaqueType.WALL_PLAQUE,
-            location: [-1668.0, 64.0, 4522.0],
+            location: [-1667.1, 5.6, 4522.5],
             inscription: `It was here that the Back Alley Brawler arrested Harry Frost for the second time. Frost was peddling a strange substance to a group of street thugs. After a lengthy court battle, the charges stuck. It seemed that the War on Drugs had achieved a critical victory.`,
             notes: `This plaque is in [map:${Boomtown.key}], 195 yards due east of the The Fuse neighborhood marker.`,
             vidiotMapKey: "5"


### PR DESCRIPTION
Updated icon names for: Chameleon, Do No Harm, Frontline, Meteorologist, Pwnz, and True Nemesis

Will provide updated icon files to KeyboardKitsune for the above badges, as well as for: Agent, Bodyguard, Emancipator, Negotiator, Plague Stopper, Spelunker, and Spirit Warrior.

Updated the coordinates for a number of exploration badges and history plaques that were more than 10 ft in error
