### PR TITLE
Update _event-badges.ts

### DIFF
--- a/src/badge/event/_event-badges.ts
+++ b/src/badge/event/_event-badges.ts
@@ -81,6 +81,7 @@ import {ANemesisPlot} from "./a-nemesis-plot";
 import {Arriviste} from "./arriviste";
 import {Resurgent} from "./resurgent";
 import {Snowbound} from "./snowbound";
+import {Legendary} from "./legendary";
 
 export const EventBadges: IBadgeData[] = [
     Celebrant,
@@ -99,6 +100,7 @@ export const EventBadges: IBadgeData[] = [
     Everlasting,
     Excelsior,
     Resurgent,
+    Legendary,
     Pursuer,
     HallowSpirit,
     IronWarrior,

--- a/src/badge/event/resurgent.ts
+++ b/src/badge/event/resurgent.ts
@@ -10,5 +10,5 @@ export const Resurgent: IBadgeData = {
     alignment: ALIGNMENT_ANY,
     badgeText: [{value: `You have helped celebrate the 16th anniversary of City of Heroes.`}],
     icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/event/resurgent.png"}],
-    acquisition: "Auto-awarded during May 2020, and thereafter available for purchase from Luna in Ouroboros during the anniversary event in May."
+    acquisition: "Available for purchase from Luna in Ouroboros during the anniversary event in May."
 };


### PR DESCRIPTION
added Legendary badge to order list (verified order in-game)

This change, along with the files that CheeseTheMonkey added for the Legendary badge and its icon, should cover everything to add Legendary to the site