### PR TITLE
Rename [Shopkeeper] tp [Proprietor]

### DIFF
--- a/src/badge/consignment/_consignment-badges.ts
+++ b/src/badge/consignment/_consignment-badges.ts
@@ -14,7 +14,7 @@ import {Dealer} from "./dealer";
 import {Auctioneer} from "./auctioneer";
 import {Businessman} from "./businessman";
 import {Marketer} from "./marketer";
-import {Shopkeeper} from "./shopkeeper";
+import {Proprietor} from "./proprietor";
 import {PowerSeller} from "./power-seller";
 
 
@@ -34,6 +34,6 @@ export const ConsignmentBadges: IBadgeData[] = [
     Auctioneer,
     Businessman,
     Marketer,
-    Shopkeeper,
+    Proprietor,
     PowerSeller
 ];

--- a/src/badge/consignment/proprietor.ts
+++ b/src/badge/consignment/proprietor.ts
@@ -1,11 +1,11 @@
 import {ALIGNMENT_ANY, Alternate, BadgeType, IBadgeData} from "coh-content-db";
 
-export const Shopkeeper: IBadgeData = {
+export const Proprietor: IBadgeData = {
     type: BadgeType.CONSIGNMENT,
-    key: "shopkeeper",
+    key: "proprietor",
     setTitleId: 820,
     names: [
-        {value: "Shopkeeper"},
+        {value: "Proprietor"},
     ],
     alignment: ALIGNMENT_ANY,
     badgeText: [
@@ -14,7 +14,7 @@ export const Shopkeeper: IBadgeData = {
     ],
     acquisition: "6000 total sales of any kind on the consignment houses.",
     links: [
-        {title: "Shopkeeper Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Shopkeeper_Badge"}
+        {title: "Proprietor Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Proprietor_Badge"}
     ],
-    icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/consignment/shopkeeper.png"}]
+    icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/consignment/proprietor.png"}]
 };

--- a/src/badge/consignment/proprietor.ts
+++ b/src/badge/consignment/proprietor.ts
@@ -2,7 +2,7 @@ import {ALIGNMENT_ANY, Alternate, BadgeType, IBadgeData} from "coh-content-db";
 
 export const Proprietor: IBadgeData = {
     type: BadgeType.CONSIGNMENT,
-    key: "proprietor",
+    key: "shopkeeper",
     setTitleId: 820,
     names: [
         {value: "Proprietor"},


### PR DESCRIPTION
Renamed shopkeeper.ts to proprietor.ts and modified that file to reflect badge name change. Changed badge name in consignment badge order file.

I tried to rename the badge icon image file but it wouldn't let me, so when this is merged you'll need to go into docs/images/badges/consignment/ and rename shopkeeper.png to proprietor.png