### PR TITLE
Pumicite Lords count for Volcanic

### DIFF
--- a/src/badge/defeat/volcanic.ts
+++ b/src/badge/defeat/volcanic.ts
@@ -11,7 +11,7 @@ export const Volcanic: IBadgeData = {
     badgeText: [
         {value: "You have cracked the Igneous bosses, earning you the right to call yourself Volcanic."}
     ],
-    acquisition: "Defeat 100 Magmite Lords",
+    acquisition: "Defeat 100 Magmite Lords or Pumicite Lords",
     links: [
         {title: "Volcanic Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Volcanic_Badge"}
     ],


### PR DESCRIPTION
New Pumicite Lord bosses added in revamped Cavern of Transcendence trial. I verified that they count toward the Volcanic badge.