### PR TITLE
Accolade update

### DIFF
--- a/src/badge/accolade/aftershock.ts
+++ b/src/badge/accolade/aftershock.ts
@@ -14,12 +14,12 @@ export const Aftershock: IBadgeData = {
     ],
     acquisition: `Complete every story arc in [map:${Faultline.key}]`,
     notes: `
-This badge rewards 20 reward merits for completing the following story arcs:
+This badge rewards 20 reward merits for completing the following story arcs (contact in parentheses):
 
-* Jim Temblor - Rumblings of the Past
-* Penelope Yin - I Lost My Daddy!
-* Doc Delilah - The Buried Past
-* Agent G - A Faultline in the Sands of Time
+* Rumblings of the Past (Jim Temblor)
+* I Lost My Daddy! (Penelope Yin)
+* The Buried Past (Doc Delilah)
+* A Faultline in the Sands of Time (Agent G)
 `,
     links: [
         {title: "Aftershock Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Aftershock_Badge"}

--- a/src/badge/accolade/aftershock.ts
+++ b/src/badge/accolade/aftershock.ts
@@ -12,7 +12,15 @@ export const Aftershock: IBadgeData = {
     badgeText: [
         {value: `You've obtained this accolade by completing every story arc within Faultline.`}
     ],
-    notes: `Complete every story arc in [map:${Faultline.key}]. [Rewards 20 Merits]`,
+    acquisition: `Complete every story arc in [map:${Faultline.key}]`,
+    notes: `
+This badge rewards 20 reward merits for completing the following story arcs:
+
+* Jim Temblor - Rumblings of the Past
+* Penelope Yin - I Lost My Daddy!
+* Doc Delilah - The Buried Past
+* Agent G - A Faultline in the Sands of Time
+`,
     links: [
         {title: "Aftershock Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Aftershock_Badge"}
     ],

--- a/src/badge/accolade/agent-of-chaos.ts
+++ b/src/badge/accolade/agent-of-chaos.ts
@@ -15,6 +15,7 @@ export const AgentOfChaos: IBadgeData = {
     acquisition: `Complete every story arc in [map:${MercyIsland.key}]`,
     notes: `
 This badge rewards 20 reward merits for completing the following story arcs (contact in parentheses):
+
 * Earning Arachnos' Favor (Kalinda)
 * The Origins of the Snakes (Matthew Burke)
 * Snake Uprising (Mongoose)

--- a/src/badge/accolade/agent-of-chaos.ts
+++ b/src/badge/accolade/agent-of-chaos.ts
@@ -12,7 +12,20 @@ export const AgentOfChaos: IBadgeData = {
     badgeText: [
         {value: `You've obtained this accolade by completing every story arc within Mercy Island.`}
     ],
-    notes: `Complete every story arc in [map:${MercyIsland.key}] to earn this badge. [Rewards 20 Merits]`,
+    acquisition: `Complete every story arc in [map:${MercyIsland.key}]`,
+    notes: `
+This badge rewards 20 reward merits for completing the following story arcs (contact in parentheses):
+* Earning Arachnos' Favor (Kalinda)
+* The Origins of the Snakes (Matthew Burke)
+* Snake Uprising (Mongoose)
+* Weird Science (Doctor Creed)
+* Underdogs Never Win (Operative Kuzmin)
+* Fire and Heist (Fire Wire)
+* Higher Purpose (Doctor Weber)
+* Price of Friendship (Lt. Harris)
+* The Hearts of Darkness Chapters 1, 2, and 3 (Dr. Graves)
+* Oh, Wretched Man! (Seer Marino)
+`,
     links: [
         {title: "Agent of Chaos Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Agent_of_Chaos_Badge"}
     ],

--- a/src/badge/accolade/agent-of-order.ts
+++ b/src/badge/accolade/agent-of-order.ts
@@ -13,7 +13,16 @@ export const AgentOfOrder: IBadgeData = {
         {type: Alternate.H, value: `Without heroes like you the world would fall into chaos and despair.`},
         {type: Alternate.V, value: `You leave nothing but chaos and destruction in your wake!`}
     ],
-    notes: `Complete every story arc in [map:${AtlasPark.key}] to earn this badge. [Rewards 20 Merits]`,
+    acquisition: `Complete every story arc in [map:${AtlasPark.key}]`,
+    notes: `
+This badge rewards 20 reward merits for completing the following story arcs (contact in parentheses):
+
+* What Was Lost (Matthew Habashy)
+* No More Fears (Officer Fields)
+* Reason to Fight (Aaron Thiery)
+* Lay Down Your Burdens (Sondra Costel)
+* The Shining Stars Chapters 1, 2, and 3 (Twinshot)
+`,
     links: [
         {title: "Agent of Order Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Agent_of_Order_Badge"}
     ],

--- a/src/badge/accolade/agent-of-praetoria.ts
+++ b/src/badge/accolade/agent-of-praetoria.ts
@@ -13,7 +13,7 @@ export const AgentOfPraetoria: IBadgeData = {
         {value: `You stand on the fragile tipping point between Order and Chaos. Which way will you go?`}
     ],
     acquisition: `Complete every story arc in [map:${NovaPraetoria.key}]`,
-    notes: `This badge rewards 20 reward merits`,
+    notes: `This badge rewards 20 reward merits.`,
     links: [
         {title: "Agent of Praetoria Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Agent_of_Praetoria_Badge"}
     ],

--- a/src/badge/accolade/agent-of-praetoria.ts
+++ b/src/badge/accolade/agent-of-praetoria.ts
@@ -12,7 +12,8 @@ export const AgentOfPraetoria: IBadgeData = {
     badgeText: [
         {value: `You stand on the fragile tipping point between Order and Chaos. Which way will you go?`}
     ],
-    notes: `Complete every story arc in [map:${NovaPraetoria.key}] to earn this badge. [Rewards 20 Merits]`,
+    acquisition: `Complete every story arc in [map:${NovaPraetoria.key}]`,
+    notes: `This badge rewards 20 reward merits`,
     links: [
         {title: "Agent of Praetoria Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Agent_of_Praetoria_Badge"}
     ],

--- a/src/badge/accolade/alpha-unlocked.ts
+++ b/src/badge/accolade/alpha-unlocked.ts
@@ -11,7 +11,8 @@ export const AlphaUnlocked: IBadgeData = {
     badgeText: [
         {value: `You unlocked your Alpha Incarnate slot allowing you to create powerful new abilities that can be slotted there.`}
     ],
-    notes: `Unlock your Alpha Incarnate slot`,
+    acquisition: `Unlock the Alpha Incarnate slot`,
+    notes: `Unlock the Alpha Incarnate slot by reaching level 50 and completing Mender Ramiel's story arc, or by earning Incarnate Experience through normal play.`,
     links: [
         {title: "Alpha Unlocked Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Alpha_Unlocked_Badge"}
     ],

--- a/src/badge/accolade/anti-venom.ts
+++ b/src/badge/accolade/anti-venom.ts
@@ -13,7 +13,8 @@ export const AntiVenom: IBadgeData = {
         {type: Alternate.H, value: `You've broken your ties with Ghost Widow, but you can never tell for sure. Be careful, or your former Patron may claim your spirit from afar.`},
         {type: Alternate.V, value: `In a world of treachery who can you trust but Ghost Widow?`}
     ],
-    notes: `Complete Ghost Widow's patron story arc`,
+    acquisition: `Complete Ghost Widow's patron story arc`,
+    notes: `Completing the patron story arc 'Mystic Mayhem' from Ghost Widow unlocks the Soul Mastery patron power pool as well as awarding this badge.`,
     links: [
         {title: "Anti-Venom Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Anti-Venom_Badge"},
         {title: "Spider's Kiss Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Spider%27s_Kiss_Badge"}

--- a/src/badge/accolade/anti-venom.ts
+++ b/src/badge/accolade/anti-venom.ts
@@ -14,7 +14,7 @@ export const AntiVenom: IBadgeData = {
         {type: Alternate.V, value: `In a world of treachery who can you trust but Ghost Widow?`}
     ],
     acquisition: `Complete Ghost Widow's patron story arc`,
-    notes: `Completing the patron story arc 'Mystic Mayhem' from Ghost Widow unlocks the Soul Mastery patron power pool as well as awarding this badge.`,
+    notes: `Completing the patron story arc 'Mystic Mayhem' from Ghost Widow in Grandville unlocks the Soul Mastery patron power pool as well as awarding this badge.`,
     links: [
         {title: "Anti-Venom Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Anti-Venom_Badge"},
         {title: "Spider's Kiss Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Spider%27s_Kiss_Badge"}

--- a/src/badge/accolade/awarded-the-freedom-cross.ts
+++ b/src/badge/accolade/awarded-the-freedom-cross.ts
@@ -12,7 +12,8 @@ export const AwardedTheFreedomCross: IBadgeData = {
     badgeText: [
         {value: `Powerful energies of the Terra Volta reactor have permanently fused with your own, modifying them in dramatic ways.`}
     ],
-    notes: `Complete the level 44-50 Terra Volta Respecification Trial from Major Richard Flagg`,
+    acquisition: `Complete the third Terra Volta Respecification Trial`,
+    notes: `The third (level 44-50) Terra Volta Respecification Trial is available from Major Richard Flagg in Peregrine Island.`,
     links: [
         {title: "Awarded the Freedom Cross Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Awarded_the_Freedom_Cross_Badge"},
         {title: "Stripped of the Freedom Cross Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Stripped_of_the_Freedom_Cross_Badge"}

--- a/src/badge/accolade/bug-hunter.ts
+++ b/src/badge/accolade/bug-hunter.ts
@@ -11,9 +11,8 @@ export const BugHunter: IBadgeData = {
     badgeText: [
         {value: `Your stalwart efforts in tracking down and eradicating evil bugs have been recognized by the Paragon City authorities. Thanks to you, the City of Heroes has its pests firmly under control.`}
     ],
-    notes: `Have a Developer recognize a game-breaking bug that you discovered and reported.
-
-**Note: This badge is not included in badge totals.**`,
+    acquisition: `Awarded by the game developers for reporting a serious and/or game-breaking bug.`,
+    notes: `**This badge is not included in badge totals.**`,
     links: [
         {title: "Bug Hunter Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Bug_Hunter_Badge"}
     ],

--- a/src/badge/accolade/destiny-unlocked.ts
+++ b/src/badge/accolade/destiny-unlocked.ts
@@ -11,7 +11,8 @@ export const DestinyUnlocked: IBadgeData = {
     badgeText: [
         {value: `You unlocked your Destiny Incarnate slot allowing you to create powerful new abilities that can be slotted there.`}
     ],
-    notes: `Unlock your Destiny Incarnate slot`,
+    acquisition: `Unlock the Destiny Incarnate slot`,
+    notes: `Unlock the Destiny Incarnate slot by earning Incarnate Experience through normal play.`,
     links: [
         {title: "Destiny Unlocked Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Destiny_Unlocked_Badge"}
     ],

--- a/src/badge/accolade/destroyer-of-despair.ts
+++ b/src/badge/accolade/destroyer-of-despair.ts
@@ -1,5 +1,22 @@
-import {ALIGNMENT_ANY, BadgeType, IBadgeData} from "coh-content-db";
+import {ALIGNMENT_ANY, BadgePartialType, badgeReference, BadgeType, IBadgeData} from "coh-content-db";
 import {DarkAstoria} from "../../map/dark-astoria";
+import {EyeOfVengeance} from "../accomplishment/eye-of-vengeance";
+import {TheDeterminedMentor} from "../accomplishment/the-determined-mentor";
+import {KnifeButcher} from "../accomplishment/knife-butcher";
+import {HunterOfSpecters} from "../accomplishment/hunter-of-specters";
+import {TheTimelessAdventurer} from "../accomplishment/the-timeless-adventurer";
+import {HeartOfHatred} from "../accomplishment/heart-of-hatred";
+import {ArchitectWriter} from "../accomplishment/architect-writer";
+import {BoundForGlory} from "../accomplishment/bound-for-glory";
+import {NaniteMan} from "../accomplishment/nanite-man";
+import {PraetorSelfish} from "../accomplishment/praetor-selfish";
+import {CimeroranHero} from "../accomplishment/cimeroran-hero";
+import {TruthTeller} from "../accomplishment/truth-teller";
+import {TimeSaver} from "../achievement/time-saver";
+import {KnowsNoFear} from "../achievement/knows-no-fear";
+import {IncarnateRival} from "../achievement/incarnate-rival";
+import {BuddyCop} from "../achievement/buddy-cop";
+import {LoneWolf} from "../achievement/lone-wolf";
 
 export const DestroyerOfDespair: IBadgeData = {
     type: BadgeType.ACCOLADE,
@@ -12,11 +29,37 @@ export const DestroyerOfDespair: IBadgeData = {
     badgeText: [
         {value: `Mot represented hatred and despair. It tried to twist the memories of all those it came across, aiming to make them believe there was no hope in their lives, that all of their hopes and dreams were meaningless. You fully conquered the forces of Mot and showed the creature just how wrong it was.`}
     ],
-    notes: `Collect all six story arc completion badges, all six personal mission completion badges, and all five mission achievement badges in [map:${DarkAstoria.key}]`,
+    notes: `
+Collect
+
+* All six story arc completion badges (${badgeReference(EyeOfVengeance)}, ${badgeReference(TheDeterminedMentor)}, ${badgeReference(KnifeButcher)}, ${badgeReference(HunterOfSpecters)}, ${badgeReference(TheTimelessAdventurer)}, and ${badgeReference(HeartOfHatred)})
+* All six personal mission completion badges (${badgeReference(ArchitectWriter)}, ${badgeReference(BoundForGlory)}, ${badgeReference(NaniteMan)}, ${badgeReference(PraetorSelfish)}, ${badgeReference(CimeroranHero)}, and ${badgeReference(TruthTeller)})
+* All five mission achievement badges (${badgeReference(TimeSaver)}, ${badgeReference(KnowsNoFear)}, ${badgeReference(IncarnateRival)}, ${badgeReference(BuddyCop)}, and ${badgeReference(LoneWolf)})
+
+in [map:${DarkAstoria.key}]`,
     links: [
         {title: "Destroyer of Despair Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Destroyer_of_Despair_Badge"}
     ],
     icons: [
         {value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accolade/destroyer-of-despair.png"}
+    ],
+    partials: [
+        {key: EyeOfVengeance.key, type: BadgePartialType.BADGE, badgeKey: EyeOfVengeance.key},
+        {key: TheDeterminedMentor.key, type: BadgePartialType.BADGE, badgeKey: TheDeterminedMentor.key},
+        {key: KnifeButcher.key, type: BadgePartialType.BADGE, badgeKey: KnifeButcher.key},
+        {key: HunterOfSpecters.key, type: BadgePartialType.BADGE, badgeKey: HunterOfSpecters.key},
+        {key: TheTimelessAdventurer.key, type: BadgePartialType.BADGE, badgeKey: TheTimelessAdventurer.key},
+        {key: HeartOfHatred.key, type: BadgePartialType.BADGE, badgeKey: HeartOfHatred.key},
+        {key: ArchitectWriter.key, type: BadgePartialType.BADGE, badgeKey: ArchitectWriter.key},
+        {key: BoundForGlory.key, type: BadgePartialType.BADGE, badgeKey: BoundForGlory.key},
+        {key: NaniteMan.key, type: BadgePartialType.BADGE, badgeKey: NaniteMan.key},
+        {key: PraetorSelfish.key, type: BadgePartialType.BADGE, badgeKey: PraetorSelfish.key},
+        {key: CimeroranHero.key, type: BadgePartialType.BADGE, badgeKey: CimeroranHero.key},
+        {key: TruthTeller.key, type: BadgePartialType.BADGE, badgeKey: TruthTeller.key},
+        {key: TimeSaver.key, type: BadgePartialType.BADGE, badgeKey: TimeSaver.key},
+        {key: KnowsNoFear.key, type: BadgePartialType.BADGE, badgeKey: KnowsNoFear.key},
+        {key: IncarnateRival.key, type: BadgePartialType.BADGE, badgeKey: IncarnateRival.key},
+        {key: BuddyCop.key, type: BadgePartialType.BADGE, badgeKey: BuddyCop.key},
+        {key: LoneWolf.key, type: BadgePartialType.BADGE, badgeKey: LoneWolf.key}
     ]
 };

--- a/src/badge/accolade/determined.ts
+++ b/src/badge/accolade/determined.ts
@@ -11,8 +11,9 @@ export const Determined: IBadgeData = {
     alignment: ALIGNMENT_ANY,
     badgeText: [
         {value: `You've obtained this accolade by completing every story arc within Dark Astoria.`}
-    ],
-    notes: `Complete every story arc in [map:${DarkAstoria.key}] to earn this badge. [Rewards 20 Merits]`,
+    ],   
+    acquisition: `Complete every story arc in [map:${DarkAstoria.key}]`,
+    notes: `This badge rewards 20 reward merits`,
     links: [
         {title: "Determined Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Determined_Badge"}
     ],

--- a/src/badge/accolade/determined.ts
+++ b/src/badge/accolade/determined.ts
@@ -13,7 +13,7 @@ export const Determined: IBadgeData = {
         {value: `You've obtained this accolade by completing every story arc within Dark Astoria.`}
     ],   
     acquisition: `Complete every story arc in [map:${DarkAstoria.key}]`,
-    notes: `This badge rewards 20 reward merits`,
+    notes: `This badge rewards 20 reward merits.`,
     links: [
         {title: "Determined Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Determined_Badge"}
     ],

--- a/src/badge/accolade/earned-the-statesman-star.ts
+++ b/src/badge/accolade/earned-the-statesman-star.ts
@@ -12,7 +12,8 @@ export const EarnedTheStatesmanStar: IBadgeData = {
     badgeText: [
         {value: `Your Terra Volta experience has altered your powers in ways no one could imagine.`}
     ],
-    notes: `Complete the level 34-43 Terra Volta Respecification Trial from Captain James Harlan`,
+    acquisition: `Complete the second Terra Volta Respecification Trial`,
+    notes: `The second (level 34-43) Terra Volta Respecification Trial is available from Captain James Harlan in Founders' Falls.`,
     links: [
         {title: "Earned the Statesman Star Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Earned_the_Statesman_Star_Badge"},
         {title: "Denied the Statesman Star Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Denied_the_Statesman_Star_Badge"}

--- a/src/badge/accolade/excavator.ts
+++ b/src/badge/accolade/excavator.ts
@@ -12,7 +12,8 @@ export const Excavator: IBadgeData = {
     badgeText: [
         {value: `You've obtained this accolade by completing every story arc within The Hollows.`}
     ],
-    notes: `Complete every story arc in [map:${TheHollows.key}]. [Rewards 20 Merits]`,
+    acquisition: `Complete every story arc in [map:${TheHollows.key}]`,
+    notes: `This badge rewards 20 reward merits`,
     links: [
         {title: "Excavator Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Excavator_Badge"}
     ],

--- a/src/badge/accolade/excavator.ts
+++ b/src/badge/accolade/excavator.ts
@@ -13,7 +13,7 @@ export const Excavator: IBadgeData = {
         {value: `You've obtained this accolade by completing every story arc within The Hollows.`}
     ],
     acquisition: `Complete every story arc in [map:${TheHollows.key}]`,
-    notes: `This badge rewards 20 reward merits`,
+    notes: `This badge rewards 20 reward merits.`,
     links: [
         {title: "Excavator Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Excavator_Badge"}
     ],

--- a/src/badge/accolade/false-image.ts
+++ b/src/badge/accolade/false-image.ts
@@ -13,7 +13,8 @@ export const FalseImage: IBadgeData = {
         {type: Alternate.H, value: `Perhaps Scirocco is secretly envious of your break to the side of honor, but he still cannot brook your betrayal.`},
         {type: Alternate.V, value: `You have chosen Scirocco's cause. He will not forget your noble gesture.`}
     ],
-    notes: `Complete Scirocco's patron story arc`,
+    acquisition: `Complete Scirocco's patron story arc`,
+    notes: `Completing the patron story arc 'A Wind Called Serafina' from Scirocco in Grandville unlocks the Mu Mastery patron power pool as well as awarding this badge.`,
     links: [
         {title: "False Image Badge", href: "https://hcwiki.cityofheroes.dev/wiki/False_Image_Badge"},
         {title: "Mirage Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Mirage_Badge"}

--- a/src/badge/accolade/fashion-victim.ts
+++ b/src/badge/accolade/fashion-victim.ts
@@ -12,7 +12,7 @@ export const FashionVictim: IBadgeData = {
     badgeText: [
         {value: `The road of excess leads to the palace of... fabulousness!`}
     ],
-    acquisition: `Spend 50 million inf at the tailor`,
+    acquisition: `Spend 50 million inf at the tailor.`,
     links: [
         {title: "Fashion Victim Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Fashion_Victim_Badge"}
     ]

--- a/src/badge/accolade/fashion-victim.ts
+++ b/src/badge/accolade/fashion-victim.ts
@@ -12,7 +12,7 @@ export const FashionVictim: IBadgeData = {
     badgeText: [
         {value: `The road of excess leads to the palace of... fabulousness!`}
     ],
-    notes: `Spend 50 million inf at the tailor`,
+    acquisition: `Spend 50 million inf at the tailor`,
     links: [
         {title: "Fashion Victim Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Fashion_Victim_Badge"}
     ]

--- a/src/badge/accolade/flames-of-prometheus.ts
+++ b/src/badge/accolade/flames-of-prometheus.ts
@@ -11,7 +11,7 @@ export const FlamesOfPrometheus: IBadgeData = {
     acquisition: `Complete the Mortimer Kal Strike Force`,
     notes: `The Mortimer Kal Strike Force is available from Mortimer Kal in Sharkhead Island.
     
-This badge can be redeemed for a Notice of the Well at 50.
+This badge can be redeemed for a Notice of the Well at level 50.
 
 **Once redeemed, this badge is no longer obtainable. This badge is not included in badge totals.**`,
     links: [

--- a/src/badge/accolade/flames-of-prometheus.ts
+++ b/src/badge/accolade/flames-of-prometheus.ts
@@ -8,11 +8,12 @@ export const FlamesOfPrometheus: IBadgeData = {
         {value: "Flames of Prometheus"}
     ],
     alignment: ALIGNMENT_VILLAIN,
-    notes: `Complete the Mortimer Kal Strike Force.
+    acquisition: `Complete the Mortimer Kal Strike Force`,
+    notes: `The Mortimer Kal Strike Force is available from Mortimer Kal in Sharkhead Island.
+    
+This badge can be redeemed for a Notice of the Well at 50.
 
-Can be redeemed for a Notice of the Well at 50
-
-**Note: once redeemed, this badge is no longer obtainable. This badge is also not included in badge totals.**`,
+**Once redeemed, this badge is no longer obtainable. This badge is not included in badge totals.**`,
     links: [
         {title: "Flames of Prometheus Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Flames_of_Prometheus"}
     ],

--- a/src/badge/accolade/fwoosh.ts
+++ b/src/badge/accolade/fwoosh.ts
@@ -13,7 +13,8 @@ export const Fwoosh: IBadgeData = {
         {type: Alternate.H, value: `This is the sound Black Scorpion's arm cannon will make when you run into him next. Didn't you learn not to peeve the guy in powered armor?`},
         {type: Alternate.V, value: `Pretty soon, nobody's gonna be able to touch me. Stick with me and you'll go places,' Black Scorpion said approvingly.`}
     ],
-    notes: `Complete Black Scorpion's patron story arc`,
+    acquisition: `Complete Black Scorpion's patron story arc`,
+    notes: `Completing the patron story arc 'Armor Wars' from Black Scorpion in Grandville unlocks the Mace Mastery patron power pool as well as awarding this badge.`,
     links: [
         {title: "Fwoosh Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Fwoosh_Badge"},
         {title: "The Stinger Badge", href: "https://hcwiki.cityofheroes.dev/wiki/The_Stinger_Badge"}

--- a/src/badge/accolade/hologram.ts
+++ b/src/badge/accolade/hologram.ts
@@ -11,7 +11,8 @@ export const Hologram: IBadgeData = {
     badgeText: [
         {value: `Thank you for your purchase of the BenevoLabs© BL-22c Holographic Matrix™! This intuitive, all-in-one system will automatically install and manage any hologram costumes you own, allowing you to access all of them from one handy location! We look forward to your continued patronage!`}
     ],
-    notes: `Purchased from BenevoLabs vendors in any Vault Reserve location for 50 Prismatic Aether salvage`,
+    acquisition: `Purchase from BenevoLabs vendors for 50 Prismatic Aether salvage`,
+    notes: `BenevoLabs vendors can be found at any Vault Reserve location.`,
     links: [
         {title: "Hologram Badge", href: "https://homecoming.wiki/wiki/Hologram_Badge"}
     ],

--- a/src/badge/accolade/hybrid-unlocked.ts
+++ b/src/badge/accolade/hybrid-unlocked.ts
@@ -11,7 +11,8 @@ export const HybridUnlocked: IBadgeData = {
     badgeText: [
         {value: `You unlocked your Hybrid Incarnate slot allowing you to create powerful new abilities that can be slotted there.`}
     ],
-    notes: `Unlock your Hybrid Incarnate slot`,
+    acquisition: `Unlock the Hybrid Incarnate slot`,
+    notes: `Unlock the Hybrid Incarnate slot by earning Incarnate Experience through normal play.`,
     links: [
         {title: "Hybrid Unlocked Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Hybrid_Unlocked_Badge"}
     ],

--- a/src/badge/accolade/interface-unlocked.ts
+++ b/src/badge/accolade/interface-unlocked.ts
@@ -11,7 +11,8 @@ export const InterfaceUnlocked: IBadgeData = {
     badgeText: [
         {value: `You unlocked your Interface Incarnate slot allowing you to create powerful new abilities that can be slotted there.`}
     ],
-    notes: `Unlock your Interface Incarnate slot`,
+    acquisition: `Unlock the Interface Incarnate slot`,
+    notes: `Unlock the Interface Incarnate slot by earning Incarnate Experience through normal play.`,
     links: [
         {title: "Interface Unlocked Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Interface_Unlocked_Badge"}
     ],

--- a/src/badge/accolade/judgement-unlocked.ts
+++ b/src/badge/accolade/judgement-unlocked.ts
@@ -11,7 +11,8 @@ export const JudgementUnlocked: IBadgeData = {
     badgeText: [
         {value: `You unlocked your Judgement Incarnate slot allowing you to create powerful new abilities that can be slotted there.`}
     ],
-    notes: `Unlock your Judgement Incarnate slot`,
+    acquisition: `Unlock the Judgement Incarnate slot`,
+    notes: `Unlock the Judgement Incarnate slot by earning Incarnate Experience through normal play.`,
     links: [
         {title: "Judgement Unlocked Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Judgement_Unlocked_Badge"}
     ],

--- a/src/badge/accolade/lore-unlocked.ts
+++ b/src/badge/accolade/lore-unlocked.ts
@@ -11,7 +11,8 @@ export const LoreUnlocked: IBadgeData = {
     badgeText: [
         {value: `You unlocked your Lore Incarnate slot allowing you to create powerful new abilities that can be slotted there.`}
     ],
-    notes: `Unlock your Lore Incarnate slot`,
+    acquisition: `Unlock the Lore Incarnate slot`,
+    notes: `Unlock the Lore Incarnate slot by earning Incarnate Experience through normal play.`,
     links: [
         {title: "Lore Unlocked Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Lore_Unlocked_Badge"}
     ],

--- a/src/badge/accolade/port-authority.ts
+++ b/src/badge/accolade/port-authority.ts
@@ -13,7 +13,7 @@ export const PortAuthority: IBadgeData = {
         {value: `You've obtained this accolade by completing every story arc within Striga Isle.`}
     ],
     acquisition: `Complete every story arc in [map:${StrigaIsle.key}]`,
-    notes: `This badge rewards 20 reward merits`,
+    notes: `This badge rewards 20 reward merits.`,
     links: [
         {title: "Port Authority Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Port_Authority_Badge"}
     ],

--- a/src/badge/accolade/port-authority.ts
+++ b/src/badge/accolade/port-authority.ts
@@ -12,7 +12,8 @@ export const PortAuthority: IBadgeData = {
     badgeText: [
         {value: `You've obtained this accolade by completing every story arc within Striga Isle.`}
     ],
-    notes: `Complete every story arc in [map:${StrigaIsle.key}]. [Rewards 20 Merits]`,
+    acquisition: `Complete every story arc in [map:${StrigaIsle.key}]`,
+    notes: `This badge rewards 20 reward merits`,
     links: [
         {title: "Port Authority Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Port_Authority_Badge"}
     ],

--- a/src/badge/accolade/praetorias-son.ts
+++ b/src/badge/accolade/praetorias-son.ts
@@ -12,7 +12,7 @@ export const PraetoriasSon: IBadgeData = {
     badgeText: [
         {value: `Praetoria is your world, for better or worse.`}
     ],
-    notes: `Awarded on creation of a Praetorian-origin character`,
+    acquisition: `Awarded on initial login of a Praetorian-origin character`,
     links: [
         {title: "Praetoria's Son Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Praetoria%27s_Son_Badge"},
         {title: "Praetoria's Daughter Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Praetoria%27s_Daughter_Badge"}

--- a/src/badge/accolade/received-the-stalwart-medallion.ts
+++ b/src/badge/accolade/received-the-stalwart-medallion.ts
@@ -12,7 +12,8 @@ export const ReceivedTheStalwartMedallion: IBadgeData = {
     badgeText: [
         {value: `Your battle in the reactor of Terra Volta altered your powers in a permanent way.`}
     ],
-    notes: `Complete the level 24-33 Terra Volta Respecification Trial from Jane Hallaway`,
+    acquisition: `Complete the first Terra Volta Respecification Trial`,
+    notes: `The first (level 24-33) Terra Volta Respecification Trial is available from Jane Hallaway in Independence Port.`,
     links: [
         {title: "Received the Stalwart Medallion Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Received_the_Stalwart_Medallion_Badge"},
         {title: "Lost the Stalwart Medallion Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Lost_the_Stalwart_Medallion_Badge"}

--- a/src/badge/accolade/recluses-betrayer.ts
+++ b/src/badge/accolade/recluses-betrayer.ts
@@ -13,8 +13,9 @@ export const ReclusesBetrayer: IBadgeData = {
         {type: Alternate.H, value: `Lord Recluse was wrong to place his trust in you.`},
         {type: Alternate.V, value: `You are the most villainous of villains and I, Lord Recluse, am proud of you!`}
     ],
+    acquisition: `Complete every story arc from Black Scorpion, Captain Mako, Ghost Widow, Scirocco, and Lord Recluse`,
+    notes: `This badge rewards 20 reward merits.`,
     icons: [{value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accolade/recluses-betrayer.png"}],
-    notes: `Complete every story arc from Black Scorpion, Captain Mako, Ghost Widow, Scirocco and Lord Recluse to earn this badge. [Rewards 20 Merits]`,
     links: [
         {title: "Recluse's Betrayer Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Recluse%27s_Betrayer_Badge"},
         {title: "Recluse's Right Hand Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Recluse%27s_Right_Hand_Badge"}

--- a/src/badge/accolade/rising-star.ts
+++ b/src/badge/accolade/rising-star.ts
@@ -12,7 +12,8 @@ export const RisingStar: IBadgeData = {
     badgeText: [
         {value: `You've obtained this accolade by completing every story arc within Imperial City.`}
     ],
-    notes: `Complete every story arc in [map:${ImperialCity.key}] to earn this badge. [Rewards 20 Merits]`,
+    acquisition: `Complete every story arc in [map:${ImperialCity.key}]`,
+    notes: `This badge rewards 20 reward merits.`,
     links: [
         {title: "Rising Star Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Rising_Star_Badge"}
     ],

--- a/src/badge/accolade/shark-bait.ts
+++ b/src/badge/accolade/shark-bait.ts
@@ -13,7 +13,8 @@ export const SharkBait: IBadgeData = {
         {type: Alternate.H, value: `Captain Mako once called you an ally. Now he calls you a snack.`},
         {type: Alternate.V, value: `You're deadly and cold-blooded. Captain Mako appreciates that.`}
     ],
-    notes: `Complete Captain Mako's patron story arc`,
+    acquisition: `Complete Captain Mako's patron story arc`,
+    notes: `Completing the patron story arc 'Killer Instinct' from Captain Mako in Grandville unlocks the Leviathan Mastery patron power pool as well as awarding this badge.`,
     links: [
         {title: "Shark Bait Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Shark_Bait_Badge"},
         {title: "Bloodletter Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Bloodletter_Badge"}

--- a/src/badge/accolade/story-teller.ts
+++ b/src/badge/accolade/story-teller.ts
@@ -12,7 +12,8 @@ export const StoryTeller: IBadgeData = {
     badgeText: [
         {value: `You've obtained this accolade by completing every story arc within Croatoa.`}
     ],
-    notes: `Complete every story arc in [map:${Croatoa.key}]. [Rewards 20 Merits]`,
+    acquisition: `Complete every story arc in [map:${Croatoa.key}]`,
+    notes: `This badge rewards 20 reward merits.`,
     links: [
         {title: "Story Teller Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Story_Teller_Badge"}
     ],

--- a/src/badge/accolade/temporal-warrior.ts
+++ b/src/badge/accolade/temporal-warrior.ts
@@ -11,7 +11,7 @@ export const TemporalWarrior: IBadgeData = {
     badgeText: [
         {value: `Your connection to your home timeline has been severed. Your only purpose now is eternal battle for a future you will never reach.`},
     ],
-    notes: `Awarded on creation of a PvP-only Temporal Warrior character.`,
+    acquisition: `Awarded on initial login of a PvP-only Temporal Warrior character`,
     links: [
         {title: "Temporal Warrior Badge", href: "https://homecoming.wiki/wiki/Temporal_Warrior_Badge"},
     ],

--- a/src/badge/accolade/thorn-robber.ts
+++ b/src/badge/accolade/thorn-robber.ts
@@ -10,8 +10,9 @@ export const ThornRobber: IBadgeData = {
     alignment: ALIGNMENT_VILLAIN,
     badgeText: [
         {value: `You have stolen the power of the Nexus of Thorns with the knowledge from the demon Sparcetriel.`}
-    ],
-    notes: `Complete the level 24-33 Tree of Thorns Respecification Trial from Sparcetriel`,
+    ],   
+    acquisition: `Complete the first Tree of Thorns Respecification Trial`,
+    notes: `The first (level 24-33) Tree of Thorns Respecification Trial is available from Sparcetriel in Nerva Archipelago.`,
     links: [
         {title: "Thorn Robber Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Thorn_Robber_Badge"}
     ],

--- a/src/badge/accolade/thorn-thief.ts
+++ b/src/badge/accolade/thorn-thief.ts
@@ -11,7 +11,8 @@ export const ThornThief: IBadgeData = {
     badgeText: [
         {value: `You have stolen the power of the Nexus of Thorns with the knowledge from the demon Trepsarciel.`}
     ],
-    notes: `Complete the level 34-43 Tree of Thorns Respecification Trial from Trepsarciel`,
+    acquisition: `Complete the second Tree of Thorns Respecification Trial`,
+    notes: `The second (level 34-43) Tree of Thorns Respecification Trial is available from Trepsarciel in Nerva Archipelago.`,
     links: [
         {title: "Thorn Thief Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Thorn_Thief_Badge"}
     ],

--- a/src/badge/accolade/thorn-usurper.ts
+++ b/src/badge/accolade/thorn-usurper.ts
@@ -11,7 +11,8 @@ export const ThornUsurper: IBadgeData = {
     badgeText: [
         {value: `You have stolen the power of the Nexus of Thorns with the knowledge from the demon Ractespriel.`}
     ],
-    notes: `Complete the level 44-50 Tree of Thorns Respecification Trial from Ractespriel`,
+    acquisition: `Complete the third Tree of Thorns Respecification Trial`,
+    notes: `The third (level 44-50) Tree of Thorns Respecification Trial is available from Ractespriel in Nerva Archipelago.`,
     links: [
         {title: "Thorn Usurper Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Thorn_Usurper_Badge"}
     ],

--- a/src/badge/accolade/true-to-the-last.ts
+++ b/src/badge/accolade/true-to-the-last.ts
@@ -12,7 +12,8 @@ export const TrueToTheLast: IBadgeData = {
     badgeText: [
         {value: `Wherever you must go, whatever you must do, Praetoria will always & forever be your home, and to it you shall be True to the Last.`}
     ],
-    notes: `Complete every story arc in [map:${Neutropolis.key}] to earn this badge. [Rewards 20 Merits]`,
+    acquisition: `Complete every story arc in [map:${Neutropolis.key}]`,
+    notes: `This badge rewards 20 reward merits.`,
     links: [
         {title: "True to the Last Badge", href: "https://hcwiki.cityofheroes.dev/wiki/True_to_the_Last_Badge"}
     ],

--- a/src/badge/accolade/vigilant.ts
+++ b/src/badge/accolade/vigilant.ts
@@ -13,7 +13,15 @@ export const Vigilant: IBadgeData = {
         {type: Alternate.H, value: `You're always there when the people of Paragon City need you.`},
         {type: Alternate.V, value: `Your shadow looms over not only the Rogue Isles and Paragon City, but the entire world.`}
     ],
-    notes: `Complete every story arc in the [map:${RiktiWarZone.key}] to earn this badge. [Rewards 20 Merits]`,
+    acquisition: `Complete every story arc in [map:${RiktiWarZone.key}]`,
+    notes: `
+This badge rewards 20 reward merits for completing the following story arcs (contact in parentheses):
+* Welcome to Vanguard (Levantera)
+* The Strange Case of Benjamin A. Decker (Levantera)
+* Dreams of Peace and Acts of War (Serpent Drummer)
+* The Red and the Black (Gaussian)
+* The Horror of War (The Dark Watcher)
+`,
     links: [
         {title: "Vigilant Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Vigilant_Badge"}
     ],

--- a/src/badge/accolade/vip.ts
+++ b/src/badge/accolade/vip.ts
@@ -13,7 +13,7 @@ export const VIP: IBadgeData = {
         {type: Alternate.H, value: `Being a V.I.P. in Paragon City has many advantages associated with it.`},
         {type: Alternate.V, value: `Being one of Kalinda's Destined Ones brings with it many perks, and just as many enemies.`},
     ],
-    notes: `Awarded on creation of a Primal-origin character`,
+    acquisition: `Awarded on initial login of a Primal-origin character`,
     links: [
         {title: "V.I.P. Badge", href: "https://hcwiki.cityofheroes.dev/wiki/V.I.P._Badge"},
         {title: "Destined One Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Destined_One_Badge"},

--- a/src/badge/event/unquenchable.ts
+++ b/src/badge/event/unquenchable.ts
@@ -11,7 +11,7 @@ export const Unquenchable: IBadgeData = {
     badgeText: [
         {value: "You have helped celebrate the 18th anniversary of City of Heroes."},
     ],
-    acquisition: "Log in during May 2022 anniversary event, and subsequently available for purchase from Luna in Ouroboros during the anniversary event in May.",
+    acquisition: "Available for purchase from Luna in Ouroboros during the anniversary event in May.",
     links: [
         {title: "Unquenchable Badge", href: "https://hcwiki.cityofheroes.dev/wiki/Unquenchable_Badge"}
     ],


### PR DESCRIPTION
Based on a forums conversation I noticed several of the accolades were missing acquisition text, which should show up on the main badges page. So I edited each one to provide brief acquisition text, and adding notes as appropriate.

I also posted a new issue regarding a URL change at the HC wiki.

Thanks!